### PR TITLE
fix animation controller not disposed bug

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.4.1"
   front_end:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.1"
+    version: "0.1.0"
   front_end:
     dependency: transitive
     description:

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -851,6 +851,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
 
   @override
   void dispose() {
+    _animationController.dispose();
     super.dispose();
     widget.controller.removeListener(this._controllerListener);
   }


### PR DESCRIPTION
Currently there is a bug in not disposing the animation controller from `_SuggestionsListState<T>`. The consequence of this is if you repeatedly search in a `TypeAheadField`, it works fine on the first few times but then it will crash the UI. The exception is: `_SuggestionsListState<dynamic>#7a5ca(ticker active) was disposed with an active Ticker`.

