### PR TITLE
Fixed suggestions list scrolling and sizing

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -925,8 +925,6 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
             child: child,
           );
 
-    TypeAheadField typeAheadField = context.ancestorWidgetOfExactType(TypeAheadField);
-
     BoxConstraints constraints;
     if (widget.decoration.constraints == null) {
       constraints = BoxConstraints(


### PR DESCRIPTION
Spent a better part of the day fixing the suggestions list scrolling and resizing.

The list resizes now by setting a fixed height. The fixed height is changed whenever the keyboard is toggled on/off and then calling a rebuild. This means the list will resize to just above the keyboard or use up the entire screen.

Please edit as you see fit.

Great plugin!