### PR TITLE
Fixed crash when maxHeight is negative

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1304,7 +1304,7 @@ class _SuggestionsBoxController {
           textBoxAbsY -
           2 * widget.suggestionsBoxVerticalOffset;
 
-      if (maxHeight <= 0) maxHeight = defaultHeight;
+      if (maxHeight < 0) maxHeight = 0;
 
       _overlayEntry.markNeedsBuild();
     }

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -227,6 +227,7 @@
 library flutter_typeahead;
 
 import 'dart:async';
+import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -937,6 +938,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       );
     } else {
       constraints = widget.decoration.constraints.copyWith(
+        minHeight: min(widget.decoration.constraints.minHeight, widget.suggestionsBoxController.maxHeight),
         maxHeight: widget.suggestionsBoxController.maxHeight,
       );
     }

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -619,7 +619,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   @override
   void didChangeMetrics() {
     // catch keyboard event and resize suggestions list
-    this._suggestionsBoxController.resize();
+    this._suggestionsBoxController.onKeyboardToggled();
   }
 
   @override
@@ -646,6 +646,8 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
 
     WidgetsBinding.instance.addPostFrameCallback((duration) async {
       await this._initOverlayEntry();
+      // calculate initial suggestions list size
+      await this._suggestionsBoxController.resize();
 
       this._effectiveFocusNode.addListener(() {
         if (_effectiveFocusNode.hasFocus) {
@@ -1281,9 +1283,6 @@ class _SuggestionsBoxController {
   }
 
   Future<void> resize() async {
-    // wait for the keyboard to finish toggling
-    await _waitKeyboardToggled();
-
     // check to see if widget is still mounted
     // user may have closed the widget with the keyboard still open
     if (widgetMounted) {
@@ -1310,5 +1309,12 @@ class _SuggestionsBoxController {
 
       _overlayEntry.markNeedsBuild();
     }
+  }
+
+  Future<void> onKeyboardToggled() async {
+    // wait for the keyboard to finish toggling
+    await _waitKeyboardToggled();
+
+    await resize();
   }
 }

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1232,13 +1232,15 @@ class TextFieldConfiguration<T> {
 }
 
 class _SuggestionsBoxController {
+  static const double defaultHeight = 300.0;
+
   final BuildContext context;
 
   OverlayEntry _overlayEntry;
 
   bool _isOpened = false;
   bool widgetMounted = true;
-  double maxHeight = 300.0;
+  double maxHeight = defaultHeight;
 
   _SuggestionsBoxController(this.context);
 
@@ -1301,6 +1303,8 @@ class _SuggestionsBoxController {
           textBoxHeight -
           textBoxAbsY -
           2 * widget.suggestionsBoxVerticalOffset;
+
+      if (maxHeight <= 0) maxHeight = defaultHeight;
 
       _overlayEntry.markNeedsBuild();
     }


### PR DESCRIPTION
Fix error when maxHeight is negative. Just set the maxHeight to the defaultHeight. Error occurs when keyboard obscures text box.