### PR TITLE
 Resize suggestion box when the user scrolls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2 - 07/02/2019
+
+- Bug fix for `maxHeight` property
+
 ## 1.0.1 - 06/02/2019
 
 - Added properties `hideOnLoading`, `hideOnEmpty`, and `hideOnError` to hide the suggestions box

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3 - 12/02/2019
+
+- Resize suggestion box when scrolling
+
 ## 1.0.2 - 07/02/2019
 
 - Bug fix for `maxHeight` property

--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ errorBuilder: (BuildContext context, Object error) =>
     )
   )
 ```
+#### Hiding the Suggestions Box
+There are three scenarios when you can hide the suggestions box.
+
+Set `hideOnLoading` to true to hide the box while suggestions are being 
+retrieved. This will also ignore the `loadingBuilder`. Set `hideOnEmpty` 
+to true to hide the box when there are no suggestions. This will also ignore 
+the `noItemsFoundBuilder`. Set `hideOnError` to true to hide the box when there 
+is an error retrieving suggestions. This will also ignore the `errorBuilder`.
+
 #### Customizing the animation
 You can customize the suggestion box animation through 3 parameters: the
 `animationDuration`, the `animationStart`, and the `transitionBuilder`.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,17 +20,22 @@ class MyHomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
           appBar: AppBar(
             title: TabBar(tabs: [
               Tab(
                 text: 'Example 1: Navigation',
               ),
-              Tab(text: 'Example 2: Form')
+              Tab(text: 'Example 2: Form'),
+              Tab(text: 'Example 3: Scroll')
             ]),
           ),
-          body: TabBarView(children: [NavigationExample(), FormExample()])),
+          body: TabBarView(children: [
+            NavigationExample(),
+            FormExample(),
+            ScrollExample(),
+          ])),
     );
   }
 }
@@ -140,6 +145,45 @@ class _FormExampleState extends State<FormExample> {
         ),
       ),
     );
+  }
+}
+
+class ScrollExample extends StatelessWidget {
+  final List<String> items = List.generate(5, (index) => "Item $index");
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(children: [
+      Center(
+          child: Padding(
+        padding: const EdgeInsets.all(8.0),
+        child: Text("Suggestion box will resize when scrolling"),
+      )),
+      SizedBox(height: 200),
+      TypeAheadField<String>(
+        getImmediateSuggestions: true,
+        textFieldConfiguration: TextFieldConfiguration(
+          decoration: InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'What are you looking for?'),
+        ),
+        suggestionsCallback: (String pattern) async {
+          return items
+              .where((item) =>
+                  item.toLowerCase().startsWith(pattern.toLowerCase()))
+              .toList();
+        },
+        itemBuilder: (context, String suggestion) {
+          return ListTile(
+            title: Text(suggestion),
+          );
+        },
+        onSuggestionSelected: (String suggestion) {
+          print("Suggestion selected");
+        },
+      ),
+      SizedBox(height: 500),
+    ]);
   }
 }
 

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -659,6 +659,9 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
 
   final LayerLink _layerLink = LayerLink();
 
+  // Timer that resizes the suggestion box on each tick. Only active when the user is scrolling.
+  Timer _resizeOnScrollTimer;
+
   @override
   void didChangeMetrics() {
     // Catch keyboard event and orientation change; resize suggestions list
@@ -669,6 +672,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   void dispose() {
     this._suggestionsBoxController.widgetMounted = false;
     WidgetsBinding.instance.removeObserver(this);
+    this._resizeOnScrollTimer?.cancel();
     super.dispose();
   }
 
@@ -709,14 +713,13 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       ScrollableState scrollableState = Scrollable.of(context);
       if (scrollableState != null) {
         // The TypeAheadField is inside a scrollable widget
-        Timer timer;
         scrollableState.position.isScrollingNotifier.addListener(() {
-          bool isScrolling =
-              scrollableState.position.isScrollingNotifier.value;
-          timer?.cancel();
+          bool isScrolling = scrollableState.position.isScrollingNotifier.value;
+          _resizeOnScrollTimer?.cancel();
           if (isScrolling) {
             // Scroll started
-            timer = Timer.periodic(Duration(milliseconds: 500), (timer) {
+            _resizeOnScrollTimer =
+                Timer.periodic(Duration(milliseconds: 500), (timer) {
               _suggestionsBoxController.resize();
             });
           } else {

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1021,10 +1021,11 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         maxHeight: widget.suggestionsBoxController.maxHeight,
       );
     } else {
+      double maxHeight = min(widget.decoration.constraints.maxHeight,
+          widget.suggestionsBoxController.maxHeight);
       constraints = widget.decoration.constraints.copyWith(
-        minHeight: min(widget.decoration.constraints.minHeight,
-            widget.suggestionsBoxController.maxHeight),
-        maxHeight: widget.suggestionsBoxController.maxHeight,
+        minHeight: min(widget.decoration.constraints.minHeight, maxHeight),
+        maxHeight: maxHeight,
       );
     }
 

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -707,17 +707,20 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       }
 
       ScrollableState scrollableState = Scrollable.of(context);
-      if (scrollableState != null) { // The TypeAheadField is inside a scrollable widget
+      if (scrollableState != null) {
+        // The TypeAheadField is inside a scrollable widget
         Timer timer;
         scrollableState.position.isScrollingNotifier.addListener(() {
           bool isScrolling =
-              Scrollable.of(context).position.isScrollingNotifier.value;
+              scrollableState.position.isScrollingNotifier.value;
           timer?.cancel();
-          if (isScrolling) { // Scroll started
+          if (isScrolling) {
+            // Scroll started
             timer = Timer.periodic(Duration(milliseconds: 500), (timer) {
               _suggestionsBoxController.resize();
             });
-          } else { // Scroll finished
+          } else {
+            // Scroll finished
             _suggestionsBoxController.resize();
           }
         });

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -705,6 +705,23 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       if (this._effectiveFocusNode.hasFocus) {
         this._suggestionsBoxController.open();
       }
+
+      ScrollableState scrollableState = Scrollable.of(context);
+      if (scrollableState != null) { // The TypeAheadField is inside a scrollable widget
+        Timer timer;
+        scrollableState.position.isScrollingNotifier.addListener(() {
+          bool isScrolling =
+              Scrollable.of(context).position.isScrollingNotifier.value;
+          timer?.cancel();
+          if (isScrolling) { // Scroll started
+            timer = Timer.periodic(Duration(milliseconds: 500), (timer) {
+              _suggestionsBoxController.resize();
+            });
+          } else { // Scroll finished
+            _suggestionsBoxController.resize();
+          }
+        });
+      }
     });
   }
 
@@ -895,7 +912,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       this._error = null;
     });
 
-    var suggestions = [];
+    List<T> suggestions = [];
     Object error;
 
     final Object callbackIdentity = Object();

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -661,6 +661,8 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
 
   // Timer that resizes the suggestion box on each tick. Only active when the user is scrolling.
   Timer _resizeOnScrollTimer;
+  // The rate at which the suggestion box will resize when the user is scrolling
+  final Duration _resizeOnScrollRefreshRate = const Duration(milliseconds: 500);
 
   @override
   void didChangeMetrics() {
@@ -672,7 +674,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   void dispose() {
     this._suggestionsBoxController.widgetMounted = false;
     WidgetsBinding.instance.removeObserver(this);
-    this._resizeOnScrollTimer?.cancel();
+    _resizeOnScrollTimer?.cancel();
     super.dispose();
   }
 
@@ -719,7 +721,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
           if (isScrolling) {
             // Scroll started
             _resizeOnScrollTimer =
-                Timer.periodic(Duration(milliseconds: 500), (timer) {
+                Timer.periodic(_resizeOnScrollRefreshRate, (timer) {
               _suggestionsBoxController.resize();
             });
           } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.0.1
+version: 1.0.2
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead
 authors:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.0.2
+version: 1.0.3
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead
 authors:


### PR DESCRIPTION
I think this is an useful feature because is not uncommon that the keyboard hides the suggestion box when the TextField is positioned in the middle of some scrollable screen and then the user tries to scroll to show the suggestions.