### PR TITLE
Hide the suggestions box when keyboard is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4 - 16/02/2019
+
+- Hide the suggestions box when keyboard is hidden
+
 ## 1.0.3 - 12/02/2019
 
 - Resize suggestion box when scrolling

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -675,6 +675,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
     this._suggestionsBoxController.widgetMounted = false;
     WidgetsBinding.instance.removeObserver(this);
     _resizeOnScrollTimer?.cancel();
+    _effectiveFocusNode.dispose();
     super.dispose();
   }
 
@@ -1486,7 +1487,7 @@ class _SuggestionsBoxController {
       resize();
     }
     // hide the suggestions box if keyboard is hidden
-    if (_keyboardClosed()) {
+    if (widgetMounted && _keyboardClosed()) {
       focusNode.unfocus();
     }
   }

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -692,7 +692,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
     }
 
     this._suggestionsBoxController =
-        _SuggestionsBoxController(context, widget.direction);
+        _SuggestionsBoxController(context, _effectiveFocusNode, widget.direction);
 
     WidgetsBinding.instance.addPostFrameCallback((duration) async {
       await this._initOverlayEntry();
@@ -1349,6 +1349,7 @@ class _SuggestionsBoxController {
   static const int waitMetricsTimeoutMillis = 1000;
 
   final BuildContext context;
+  final FocusNode focusNode;
   final AxisDirection direction;
 
   OverlayEntry _overlayEntry;
@@ -1357,7 +1358,7 @@ class _SuggestionsBoxController {
   bool widgetMounted = true;
   double maxHeight = defaultHeight;
 
-  _SuggestionsBoxController(this.context, this.direction);
+  _SuggestionsBoxController(this.context, this.focusNode, this.direction);
 
   open() {
     if (this._isOpened) return;
@@ -1476,9 +1477,17 @@ class _SuggestionsBoxController {
     }
   }
 
+  bool _keyboardClosed() {
+    return MediaQuery.of(context).viewInsets.bottom <= 0;
+  }
+
   Future<void> onChangeMetrics() async {
     if (await _waitChangeMetrics()) {
       resize();
+    }
+    // hide the suggestions box if keyboard is hidden
+    if (_keyboardClosed()) {
+      focusNode.unfocus();
     }
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.0.3
+version: 1.0.4
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead
 authors:


### PR DESCRIPTION
When the keyboard is dismissed or hidden, the suggestions box will no longer show. This fixes the problem where the suggestions box hides underlying widgets. Addresses #43 .