### PR TITLE
Fix suggestions being called on TextBox focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4 - 21/02/2019
+
+- Fix suggestions being called on TextBox focus
+
 ## 1.0.3 - 12/02/2019
 
 - Resize suggestion box when scrolling

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -887,8 +887,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
     this._isLoading = false;
     this._lastTextValue = widget.controller.text;
 
-    // If we started with some text, get suggestions immediately
-    if (widget.controller.text.isNotEmpty || widget.getImmediateSuggestions) {
+    if (widget.getImmediateSuggestions) {
       this._getSuggestions();
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.0.3
+version: 1.0.4
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead
 authors:


### PR DESCRIPTION
Fixes #47 . Apparently this was coded intentionally, but this does not match the behavior on Android. Cannot say for iOS.