### PR TITLE
A bunch of fixes and hide suggestions box on keyboard hide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0 - 01/03/2019
+
+- Suggestions box now closes on keyboard hide
+- Added property `hideSuggestionsOnKeyboardHide'
+
 ## 1.0.4/5 - 21/02/2019
 
 - Fix suggestions being called on TextBox focus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Added property `hideSuggestionsOnKeyboardHide'
 - Width now properly resizes on orientation changes
 - Suggestions box will display above keyboard when keyboard hides the box for AxisDirection.Up
-- Properly dispose of focus node
+- Fix FocusNode errors
+- Fix keyboard height calculation
 
 ## 1.0.4/5 - 21/02/2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.1.0 - 01/03/2019
 
-- Suggestions box now closes on keyboard hide
+- Suggestions box now closes on keyboard hide by default
 - Added property `hideSuggestionsOnKeyboardHide'
+- Width now properly resizes on orientation changes
+- Suggestions box will display above keyboard when keyboard hides the box for AxisDirection.Up
+- Properly dispose of focus node
 
 ## 1.0.4/5 - 21/02/2019
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ to true to hide the box when there are no suggestions. This will also ignore
 the `noItemsFoundBuilder`. Set `hideOnError` to true to hide the box when there 
 is an error retrieving suggestions. This will also ignore the `errorBuilder`.
 
+By default, the suggestions box will automatically hide when the keyboard is hidden. 
+To change this behavior, set `hideSuggestionsOnKeyboardHide` to false.
+
 #### Customizing the animation
 You can customize the suggestion box animation through 3 parameters: the
 `animationDuration`, the `animationStart`, and the `transitionBuilder`.

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -675,7 +675,8 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   final Duration _resizeOnScrollRefreshRate = const Duration(milliseconds: 500);
 
   // Keyboard detection
-  KeyboardVisibilityNotification _keyboardVisibility = new KeyboardVisibilityNotification();
+  KeyboardVisibilityNotification _keyboardVisibility =
+      new KeyboardVisibilityNotification();
   int _keyboardVisibilityId;
 
   @override
@@ -719,8 +720,8 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       },
     );
 
-    WidgetsBinding.instance.addPostFrameCallback((duration) async {
-      await this._initOverlayEntry();
+    WidgetsBinding.instance.addPostFrameCallback((duration) {
+      this._initOverlayEntry();
       // calculate initial suggestions list size
       this._suggestionsBoxController.resize();
 
@@ -758,10 +759,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
     });
   }
 
-  Future<void> _initOverlayEntry() async {
-    RenderBox renderBox = context.findRenderObject();
-    var size = renderBox.size;
-
+  void _initOverlayEntry() {
     this._suggestionsBoxController._overlayEntry =
         OverlayEntry(builder: (context) {
       final suggestionsList = _SuggestionsList<T>(
@@ -789,15 +787,16 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       );
 
       return Positioned(
-        width: size.width,
+        width: _suggestionsBoxController.textBoxWidth,
         child: CompositedTransformFollower(
           link: this._layerLink,
           showWhenUnlinked: false,
           offset: Offset(
               0.0,
               widget.direction == AxisDirection.down
-                  ? size.height + widget.suggestionsBoxVerticalOffset
-                  : -widget.suggestionsBoxVerticalOffset),
+                  ? _suggestionsBoxController.textBoxHeight +
+                      widget.suggestionsBoxVerticalOffset
+                  : _suggestionsBoxController.directionUpOffset),
           child: widget.direction == AxisDirection.down
               ? suggestionsList
               : FractionalTranslation(
@@ -1369,7 +1368,6 @@ class TextFieldConfiguration<T> {
 }
 
 class _SuggestionsBoxController {
-  static const double defaultHeight = 300.0;
   static const int waitMetricsTimeoutMillis = 1000;
 
   final BuildContext context;
@@ -1379,7 +1377,10 @@ class _SuggestionsBoxController {
 
   bool _isOpened = false;
   bool widgetMounted = true;
-  double maxHeight = defaultHeight;
+  double maxHeight = 300.0;
+  double textBoxWidth = 100.0;
+  double textBoxHeight = 100.0;
+  double directionUpOffset;
 
   _SuggestionsBoxController(this.context, this.direction);
 
@@ -1446,11 +1447,14 @@ class _SuggestionsBoxController {
     if (widgetMounted) {
       TypeAheadField widget = context.widget as TypeAheadField;
 
+      RenderBox box = context.findRenderObject();
+      textBoxWidth = box.size.width;
+      textBoxHeight = box.size.height;
+
       if (direction == AxisDirection.down) {
         // height of window
         double h = MediaQuery.of(context).size.height;
 
-        RenderBox box = context.findRenderObject();
         // top of text box
         double textBoxAbsY = box.localToGlobal(Offset.zero).dy;
         double textBoxHeight = box.size.height;
@@ -1477,9 +1481,22 @@ class _SuggestionsBoxController {
             2 * widget.suggestionsBoxVerticalOffset;
       } else {
         // AxisDirection.up
-        RenderBox box = context.findRenderObject();
+        // Calculate offset when the keyboard is covering the suggestions box
+        // height of window
+        double h = MediaQuery.of(context).size.height;
+
+        // height of keyboard
+        double keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+
+        // recalculate keyboard absolute y value
+        double keyboardAbsY = h - keyboardHeight;
+
         // top of text box
         double textBoxAbsY = box.localToGlobal(Offset.zero).dy;
+
+        directionUpOffset = textBoxAbsY > keyboardAbsY
+            ? keyboardAbsY - textBoxAbsY - widget.suggestionsBoxVerticalOffset
+            : -widget.suggestionsBoxVerticalOffset;
 
         // we need to find the root MediaQuery for the unsafe area height
         // we cannot use BuildContext.ancestorWidgetOfExactType because
@@ -1489,9 +1506,13 @@ class _SuggestionsBoxController {
         // unsafe area, ie: iPhone X notch
         double unsafeAreaHeight = rootMediaQuery.data.padding.top;
 
-        maxHeight = textBoxAbsY -
-            unsafeAreaHeight -
-            2 * widget.suggestionsBoxVerticalOffset;
+        maxHeight = textBoxAbsY > keyboardAbsY
+            ? keyboardAbsY -
+                unsafeAreaHeight -
+                2 * widget.suggestionsBoxVerticalOffset
+            : textBoxAbsY -
+                unsafeAreaHeight -
+                2 * widget.suggestionsBoxVerticalOffset;
       }
 
       if (maxHeight < 0) maxHeight = 0;

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1459,13 +1459,13 @@ class _SuggestionsBoxController {
         double textBoxAbsY = box.localToGlobal(Offset.zero).dy;
         double textBoxHeight = box.size.height;
 
-        // height of keyboard
-        double keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
-
         // we need to find the root MediaQuery for the unsafe area height
         // we cannot use BuildContext.ancestorWidgetOfExactType because
         // widgets like SafeArea creates a new MediaQuery with the padding removed
         MediaQuery rootMediaQuery = _findRootMediaQuery();
+
+        // height of keyboard
+        double keyboardHeight = rootMediaQuery.data.viewInsets.bottom;
 
         // unsafe area, ie: iPhone X 'home button'
         // keyboardHeight includes unsafeAreaHeight, if keyboard is showing, set to 0
@@ -1485,8 +1485,13 @@ class _SuggestionsBoxController {
         // height of window
         double h = MediaQuery.of(context).size.height;
 
+        // we need to find the root MediaQuery for the unsafe area height
+        // we cannot use BuildContext.ancestorWidgetOfExactType because
+        // widgets like SafeArea creates a new MediaQuery with the padding removed
+        MediaQuery rootMediaQuery = _findRootMediaQuery();
+
         // height of keyboard
-        double keyboardHeight = MediaQuery.of(context).viewInsets.bottom;
+        double keyboardHeight = rootMediaQuery.data.viewInsets.bottom;
 
         // recalculate keyboard absolute y value
         double keyboardAbsY = h - keyboardHeight;
@@ -1497,11 +1502,6 @@ class _SuggestionsBoxController {
         directionUpOffset = textBoxAbsY > keyboardAbsY
             ? keyboardAbsY - textBoxAbsY - widget.suggestionsBoxVerticalOffset
             : -widget.suggestionsBoxVerticalOffset;
-
-        // we need to find the root MediaQuery for the unsafe area height
-        // we cannot use BuildContext.ancestorWidgetOfExactType because
-        // widgets like SafeArea creates a new MediaQuery with the padding removed
-        MediaQuery rootMediaQuery = _findRootMediaQuery();
 
         // unsafe area, ie: iPhone X notch
         double unsafeAreaHeight = rootMediaQuery.data.padding.top;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.0.5
+version: 1.1.0
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead
 authors:
@@ -10,6 +10,7 @@ authors:
 dependencies:
   flutter:
     sdk: flutter
+  keyboard_visibility: ^0.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Fixes #62 , #63 , #48 .

Alright, so the width now auto resizes correctly on orientation change. The findRenderObject method call was being called prematurely. Moved it so now it works. 

For AxisDirection.Up, you will most likely use this when the text box is at the bottom right? So chances are the keyboard will obscure part of the list. Now the suggestion box starts just above the keyboard so your users can see the full list.

Used [3rd party library](https://github.com/adee42/flutter_keyboard_visibility) for suggestions hiding on keyboard hide. Props to adee42 for making a good library. Works great! Added property hideSuggestionsOnKeyboardHide in case anyone hates this new functionality (can't think of why).

Someone should double-check my work just to make sure I didn't break stuff. Moved quite a bit of code around.