### PR TITLE
Fixed FocusNode crash and other various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1 - 19/03/2019
+
+- Bug fixes & optimizations
+
 ## 1.2.0 - 05/03/2019
 
 - Added property `keepSuggestionsOnLoading`

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -740,34 +740,36 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
     };
 
     WidgetsBinding.instance.addPostFrameCallback((duration) {
-      this._initOverlayEntry();
-      // calculate initial suggestions list size
-      this._suggestionsBoxController.resize();
+      if (mounted) {
+        this._initOverlayEntry();
+        // calculate initial suggestions list size
+        this._suggestionsBoxController.resize();
 
-      this._effectiveFocusNode.addListener(_focusNodeListener);
+        this._effectiveFocusNode.addListener(_focusNodeListener);
 
-      // in case we already missed the focus event
-      if (this._effectiveFocusNode.hasFocus) {
-        this._suggestionsBoxController.open();
-      }
+        // in case we already missed the focus event
+        if (this._effectiveFocusNode.hasFocus) {
+          this._suggestionsBoxController.open();
+        }
 
-      ScrollableState scrollableState = Scrollable.of(context);
-      if (scrollableState != null) {
-        // The TypeAheadField is inside a scrollable widget
-        scrollableState.position.isScrollingNotifier.addListener(() {
-          bool isScrolling = scrollableState.position.isScrollingNotifier.value;
-          _resizeOnScrollTimer?.cancel();
-          if (isScrolling) {
-            // Scroll started
-            _resizeOnScrollTimer =
-                Timer.periodic(_resizeOnScrollRefreshRate, (timer) {
+        ScrollableState scrollableState = Scrollable.of(context);
+        if (scrollableState != null) {
+          // The TypeAheadField is inside a scrollable widget
+          scrollableState.position.isScrollingNotifier.addListener(() {
+            bool isScrolling = scrollableState.position.isScrollingNotifier.value;
+            _resizeOnScrollTimer?.cancel();
+            if (isScrolling) {
+              // Scroll started
+              _resizeOnScrollTimer =
+                  Timer.periodic(_resizeOnScrollRefreshRate, (timer) {
+                _suggestionsBoxController.resize();
+              });
+            } else {
+              // Scroll finished
               _suggestionsBoxController.resize();
-            });
-          } else {
-            // Scroll finished
-            _suggestionsBoxController.resize();
-          }
-        });
+            }
+          });
+        }
       }
     });
   }

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1069,14 +1069,12 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
     Widget child;
 
     if (widget.keepSuggestionsOnLoading && this._suggestions != null) {
-      print('Create suggestions on loading');
       if (this._suggestions.isEmpty) {
         child = createNoItemsFoundWidget();
       } else {
         child = createSuggestionsWidget();
       }
     } else {
-      print('Show progress on loading');
       child = widget.loadingBuilder != null
           ? widget.loadingBuilder(context)
           : Align(

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -940,6 +940,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
 
       this._lastTextValue = widget.controller.text;
 
+      this._debounceTimer?.cancel();
       this._debounceTimer = Timer(widget.debounceDuration, () async {
         if (this._debounceTimer.isActive) return;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.2.0
+version: 1.2.1
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead
 authors:


### PR DESCRIPTION
Fixed focus node crash in instances where the typeahead widget is created and destroyed quickly.
Removed debugging print lines.
Cancelled debounceTimer before creating a new one.