### PR TITLE
add autoFlipAxis feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.0 - 26/03/2019
+
+- Added property `autoFlipDirection` to allow automatic direction flipping if 
+there is not enough space for the suggestions list
+
 ## 1.3.0 - 19/03/2019
 
 - Limit number of suggestionsCallbacks until current call is finished

--- a/README.md
+++ b/README.md
@@ -247,7 +247,9 @@ suggestionsBoxDecoration: SuggestionsBoxDecoration(
 ```
 
 #### Customizing the growth direction of the suggestions list
-By default, the list grows towards the bottom. However, you can use the `direction` property to customize the growth direction to be one of `AxisDirection.down` or `AxisDirection.up`, the latter of which will cause the list to grow up, where the first suggestion is at the bottom of the list, and the last suggestion is at the top. 
+By default, the list grows towards the bottom. However, you can use the `direction` property to customize the growth direction to be one of `AxisDirection.down` or `AxisDirection.up`, the latter of which will cause the list to grow up, where the first suggestion is at the bottom of the list, and the last suggestion is at the top.
+
+Set `autoFlipDirection` to true to allow the suggestions list to automatically flip direction whenever it detects that there is not enough space for the current direction. This is useful for scenarios where the TypeAheadField is in a scrollable widget or when the developer wants to ensure the list is always viewable despite different user screen sizes.
 
 ## For more information
 Visit the [API Documentation](https://pub.dartlang.org/documentation/flutter_typeahead/latest/)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.3.0
+version: 1.4.0
 
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead


### PR DESCRIPTION
Fix for https://github.com/AbdulRahmanAlHamali/flutter_typeahead/issues/79

If autoFlipAxis is set to true, in the case where the suggestions box has less than MIN_OVERLAY_SPACE to grow in the desired direction, the direction axis will be temporarily flipped if there's more room available in the opposite direction.  Defaults to false

