### PR TITLE
Fix height problems with animations and dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added `suggestionsBoxController` property and `SuggestionsBoxController` class to
 allow manual control of the suggestions box
 - Fix suggestions box height problems in dialogs
+- Add `textDirection` property to `TextFieldConfiguration`
 
 ## 1.4.1 09/04/2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.0 25/04/2019
+
+- Added `suggestionsBoxController` property and `SuggestionsBoxController` class to
+allow manual control of the suggestions box
+- Fix suggestions box height problems in dialogs
+
 ## 1.4.1 09/04/2019
 
 - Fixed BoxConstraints width parameters being ignored in `SuggestionsBoxDecoration`

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The `transitionBuilder` allows us to customize the animation of the
 suggestion box. In this example, we are returning the suggestionsBox
 immediately, meaning that we don't want any animation.
 
-## Warnings
+## Known Issues
 
 ### Animations
 Placing TypeAheadField in widgets with animations may cause the suggestions box 
@@ -184,6 +184,9 @@ void initState() {
     super.dispose();
 }
 ```
+
+#### Dialogs
+There is a known issue with opening dialogs where the suggestions box will sometimes appear too small. This is a timing issue caused by the animations described above. Currently, `showDialog` has a duration of 150 ms for the animations. TypeAheadField has a delay of 170 ms to compensate for this. Until the end of the animation can be properly detected and fixed using the solution above, this temporary fix will work most of the time. If the suggestions box is too small, closing and reopening the keyboard will usually fix the issue.
 
 ## Customizations
 TypeAhead widgets consist of a TextField and a suggestion box that shows

--- a/README.md
+++ b/README.md
@@ -153,6 +153,38 @@ The `transitionBuilder` allows us to customize the animation of the
 suggestion box. In this example, we are returning the suggestionsBox
 immediately, meaning that we don't want any animation.
 
+## Warnings
+
+### Animations
+Placing TypeAheadField in widgets with animations may cause the suggestions box 
+to resize incorrectly. Since animation times are variable, this has to be 
+corrected manually at the end of the animation. You will need to add a 
+SuggestionsBoxController described below and the following code for the 
+AnimationController.
+```dart
+void Function(AnimationStatus) _statusListener;
+
+@override
+void initState() {
+  super.initState();
+  _statusListener = (AnimationStatus status) {
+    if (status == AnimationStatus.completed ||
+        status == AnimationStatus.dismissed) {
+      _suggestionsBoxController.resize();
+    }
+  };
+
+  _animationController.addStatusListener(_statusListener);
+}
+
+@override
+  void dispose() {
+    _animationController.removeStatusListener(_statusListener);
+    _animationController.dispose();
+    super.dispose();
+}
+```
+
 ## Customizations
 TypeAhead widgets consist of a TextField and a suggestion box that shows
 as the user types. Both are highly customizable
@@ -164,7 +196,7 @@ which allows you to configure all the usual properties of `TextField`, like
 `decoration`, `style`, `controller`, `focusNode`, `autofocus`, `enabled`,
 etc.
 
-### Customizing the Suggestions Box
+### Customizing the suggestions box
 TypeAhead provides default configurations for the suggestions box. You can,
 however, override most of them. This is done by passing a `SuggestionsBoxDecoration` 
 to the `suggestionsBoxDecoration` property.
@@ -187,7 +219,7 @@ By default, the suggestions box will maintain the old suggestions while new
 suggestions are being retrieved. To show a circular progress indicator 
 during retrieval instead, set `keepSuggestionsOnLoading` to false.
 
-#### Hiding the Suggestions Box
+#### Hiding the suggestions box
 There are three scenarios when you can hide the suggestions box.
 
 Set `hideOnLoading` to true to hide the box while suggestions are being 
@@ -251,6 +283,11 @@ suggestionsBoxDecoration: SuggestionsBoxDecoration(
 By default, the list grows towards the bottom. However, you can use the `direction` property to customize the growth direction to be one of `AxisDirection.down` or `AxisDirection.up`, the latter of which will cause the list to grow up, where the first suggestion is at the bottom of the list, and the last suggestion is at the top.
 
 Set `autoFlipDirection` to true to allow the suggestions list to automatically flip direction whenever it detects that there is not enough space for the current direction. This is useful for scenarios where the TypeAheadField is in a scrollable widget or when the developer wants to ensure the list is always viewable despite different user screen sizes.
+
+#### Controlling the suggestions box
+Manual control of the suggestions box can be achieved by creating an instance of `SuggestionsBoxController` and 
+passing it to the `suggestionsBoxController` property. This will allow you to manually open, close, toggle, or 
+resize the suggestions box.
 
 ## For more information
 Visit the [API Documentation](https://pub.dartlang.org/documentation/flutter_typeahead/latest/)

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -268,6 +268,7 @@ class TypeAheadFormField<T> extends FormField<String> {
       Duration debounceDuration: const Duration(milliseconds: 300),
       SuggestionsBoxDecoration suggestionsBoxDecoration:
           const SuggestionsBoxDecoration(),
+      SuggestionsBoxController suggestionsBoxController,
       @required SuggestionSelectionCallback<T> onSuggestionSelected,
       @required ItemBuilder<T> itemBuilder,
       @required SuggestionsCallback<T> suggestionsCallback,
@@ -304,6 +305,7 @@ class TypeAheadFormField<T> extends FormField<String> {
                 loadingBuilder: loadingBuilder,
                 debounceDuration: debounceDuration,
                 suggestionsBoxDecoration: suggestionsBoxDecoration,
+                suggestionsBoxController: suggestionsBoxController,
                 textFieldConfiguration: textFieldConfiguration.copyWith(
                   decoration: textFieldConfiguration.decoration
                       .copyWith(errorText: state.errorText),
@@ -474,6 +476,10 @@ class TypeAheadField<T> extends StatefulWidget {
   /// If null, default decoration with an elevation of 4.0 is used
   final SuggestionsBoxDecoration suggestionsBoxDecoration;
 
+  /// Used to control the `_SuggestionsBox`. Allows manual control to
+  /// open, close, toggle, or resize the `_SuggestionsBox`.
+  final SuggestionsBoxController suggestionsBoxController;
+
   /// The duration to wait after the user stops typing before calling
   /// [suggestionsCallback]
   ///
@@ -643,6 +649,7 @@ class TypeAheadField<T> extends StatefulWidget {
       this.textFieldConfiguration: const TextFieldConfiguration(),
       this.suggestionsBoxDecoration: const SuggestionsBoxDecoration(),
       this.debounceDuration: const Duration(milliseconds: 300),
+      this.suggestionsBoxController,
       this.loadingBuilder,
       this.noItemsFoundBuilder,
       this.errorBuilder,
@@ -681,7 +688,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
     with WidgetsBindingObserver {
   FocusNode _focusNode;
   TextEditingController _textEditingController;
-  _SuggestionsBoxController _suggestionsBoxController;
+  _SuggestionsBox _suggestionsBox;
 
   TextEditingController get _effectiveController =>
       widget.textFieldConfiguration.controller ?? _textEditingController;
@@ -704,12 +711,12 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   @override
   void didChangeMetrics() {
     // Catch keyboard event and orientation change; resize suggestions list
-    this._suggestionsBoxController.onChangeMetrics();
+    this._suggestionsBox.onChangeMetrics();
   }
 
   @override
   void dispose() {
-    this._suggestionsBoxController.widgetMounted = false;
+    this._suggestionsBox.widgetMounted = false;
     WidgetsBinding.instance.removeObserver(this);
     _keyboardVisibility.removeListener(_keyboardVisibilityId);
     _effectiveFocusNode.removeListener(_focusNodeListener);
@@ -731,8 +738,9 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       this._focusNode = FocusNode();
     }
 
-    this._suggestionsBoxController = _SuggestionsBoxController(
-        context, widget.direction, widget.autoFlipDirection);
+    this._suggestionsBox =
+        _SuggestionsBox(context, widget.direction, widget.autoFlipDirection);
+    widget.suggestionsBoxController?._suggestionsBox = this._suggestionsBox;
 
     // hide suggestions box on keyboard closed
     this._keyboardVisibilityId = _keyboardVisibility.addNewListener(
@@ -745,9 +753,9 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
 
     this._focusNodeListener = () {
       if (_effectiveFocusNode.hasFocus) {
-        this._suggestionsBoxController.open();
+        this._suggestionsBox.open();
       } else {
-        this._suggestionsBoxController.close();
+        this._suggestionsBox.close();
       }
     };
 
@@ -755,13 +763,13 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       if (mounted) {
         this._initOverlayEntry();
         // calculate initial suggestions list size
-        this._suggestionsBoxController.resize();
+        this._suggestionsBox.resize();
 
         this._effectiveFocusNode.addListener(_focusNodeListener);
 
         // in case we already missed the focus event
         if (this._effectiveFocusNode.hasFocus) {
-          this._suggestionsBoxController.open();
+          this._suggestionsBox.open();
         }
 
         ScrollableState scrollableState = Scrollable.of(context);
@@ -775,11 +783,11 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
               // Scroll started
               _resizeOnScrollTimer =
                   Timer.periodic(_resizeOnScrollRefreshRate, (timer) {
-                _suggestionsBoxController.resize();
+                _suggestionsBox.resize();
               });
             } else {
               // Scroll finished
-              _suggestionsBoxController.resize();
+              _suggestionsBox.resize();
             }
           });
         }
@@ -788,10 +796,9 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   }
 
   void _initOverlayEntry() {
-    this._suggestionsBoxController._overlayEntry =
-        OverlayEntry(builder: (context) {
+    this._suggestionsBox._overlayEntry = OverlayEntry(builder: (context) {
       final suggestionsList = _SuggestionsList<T>(
-        suggestionsBoxController: _suggestionsBoxController,
+        suggestionsBox: _suggestionsBox,
         decoration: widget.suggestionsBoxDecoration,
         debounceDuration: widget.debounceDuration,
         controller: this._effectiveController,
@@ -805,17 +812,18 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
         getImmediateSuggestions: widget.getImmediateSuggestions,
         onSuggestionSelected: (T selection) {
           this._effectiveFocusNode.unfocus();
+          this._suggestionsBox.close();
           widget.onSuggestionSelected(selection);
         },
         itemBuilder: widget.itemBuilder,
-        direction: _suggestionsBoxController.direction,
+        direction: _suggestionsBox.direction,
         hideOnLoading: widget.hideOnLoading,
         hideOnEmpty: widget.hideOnEmpty,
         hideOnError: widget.hideOnError,
         keepSuggestionsOnLoading: widget.keepSuggestionsOnLoading,
       );
 
-      double w = _suggestionsBoxController.textBoxWidth;
+      double w = _suggestionsBox.textBoxWidth;
       if (widget.suggestionsBoxDecoration.constraints != null) {
         if (widget.suggestionsBoxDecoration.constraints.minWidth != 0.0 &&
             widget.suggestionsBoxDecoration.constraints.maxWidth !=
@@ -841,11 +849,11 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
           showWhenUnlinked: false,
           offset: Offset(
               0.0,
-              _suggestionsBoxController.direction == AxisDirection.down
-                  ? _suggestionsBoxController.textBoxHeight +
+              _suggestionsBox.direction == AxisDirection.down
+                  ? _suggestionsBox.textBoxHeight +
                       widget.suggestionsBoxVerticalOffset
-                  : _suggestionsBoxController.directionUpOffset),
-          child: _suggestionsBoxController.direction == AxisDirection.down
+                  : _suggestionsBox.directionUpOffset),
+          child: _suggestionsBox.direction == AxisDirection.down
               ? suggestionsList
               : FractionalTranslation(
                   translation:
@@ -892,7 +900,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
 }
 
 class _SuggestionsList<T> extends StatefulWidget {
-  final _SuggestionsBoxController suggestionsBoxController;
+  final _SuggestionsBox suggestionsBox;
   final TextEditingController controller;
   final bool getImmediateSuggestions;
   final SuggestionSelectionCallback<T> onSuggestionSelected;
@@ -913,7 +921,7 @@ class _SuggestionsList<T> extends StatefulWidget {
   final bool keepSuggestionsOnLoading;
 
   _SuggestionsList({
-    @required this.suggestionsBoxController,
+    @required this.suggestionsBox,
     this.controller,
     this.getImmediateSuggestions: false,
     this.onSuggestionSelected,
@@ -1080,11 +1088,11 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
     BoxConstraints constraints;
     if (widget.decoration.constraints == null) {
       constraints = BoxConstraints(
-        maxHeight: widget.suggestionsBoxController.maxHeight,
+        maxHeight: widget.suggestionsBox.maxHeight,
       );
     } else {
       double maxHeight = min(widget.decoration.constraints.maxHeight,
-          widget.suggestionsBoxController.maxHeight);
+          widget.suggestionsBox.maxHeight);
       constraints = widget.decoration.constraints.copyWith(
         minHeight: min(widget.decoration.constraints.minHeight, maxHeight),
         maxHeight: maxHeight,
@@ -1161,7 +1169,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       padding: EdgeInsets.zero,
       primary: false,
       shrinkWrap: true,
-      reverse: widget.suggestionsBoxController.direction == AxisDirection.down
+      reverse: widget.suggestionsBox.direction == AxisDirection.down
           ? false
           : true, // reverses the list to start at the bottom
       children: this._suggestions.map((T suggestion) {
@@ -1456,7 +1464,7 @@ class TextFieldConfiguration<T> {
   }
 }
 
-class _SuggestionsBoxController {
+class _SuggestionsBox {
   static const int waitMetricsTimeoutMillis = 1000;
   static const double minOverlaySpace = 64.0;
 
@@ -1474,25 +1482,24 @@ class _SuggestionsBoxController {
   double textBoxHeight = 100.0;
   double directionUpOffset;
 
-  _SuggestionsBoxController(
-      this.context, this.direction, this.autoFlipDirection)
+  _SuggestionsBox(this.context, this.direction, this.autoFlipDirection)
       : desiredDirection = direction;
 
-  open() {
+  void open() {
     if (this._isOpened) return;
     assert(this._overlayEntry != null);
     Overlay.of(context).insert(this._overlayEntry);
     this._isOpened = true;
   }
 
-  close() {
+  void close() {
     if (!this._isOpened) return;
     assert(this._overlayEntry != null);
     this._overlayEntry.remove();
     this._isOpened = false;
   }
 
-  toggle() {
+  void toggle() {
     if (this._isOpened) {
       this.close();
     } else {
@@ -1527,8 +1534,9 @@ class _SuggestionsBoxController {
             _findRootMediaQuery() != initialRootMediaQuery) {
           return true;
         }
-        await Future.delayed(const Duration(milliseconds: 10));
-        timer += 10;
+        // TODO: reduce delay if showDialog ever exposes detection of animation end
+        await Future.delayed(const Duration(milliseconds: 150));
+        timer += 150;
       }
     }
 
@@ -1656,5 +1664,29 @@ class _SuggestionsBoxController {
     if (await _waitChangeMetrics()) {
       resize();
     }
+  }
+}
+
+class SuggestionsBoxController {
+  _SuggestionsBox _suggestionsBox;
+
+  /// Opens the suggestions box
+  void open() {
+    _suggestionsBox?.open();
+  }
+
+  /// Closes the suggestions box
+  void close() {
+    _suggestionsBox?.close();
+  }
+
+  /// Opens the suggestions box if closed and vice-versa
+  void toggle() {
+    _suggestionsBox?.toggle();
+  }
+
+  /// Recalculates the height of the suggestions box
+  void resize() {
+    _suggestionsBox?.resize();
   }
 }

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1530,13 +1530,14 @@ class _SuggestionsBox {
       int timer = 0;
       // viewInsets or MediaQuery have changed once keyboard has toggled or orientation has changed
       while (widgetMounted && timer < waitMetricsTimeoutMillis) {
+        // TODO: reduce delay if showDialog ever exposes detection of animation end
+        await Future.delayed(const Duration(milliseconds: 170));
+        timer += 170;
+        
         if (MediaQuery.of(context).viewInsets != initial ||
             _findRootMediaQuery() != initialRootMediaQuery) {
           return true;
         }
-        // TODO: reduce delay if showDialog ever exposes detection of animation end
-        await Future.delayed(const Duration(milliseconds: 150));
-        timer += 150;
       }
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.4.1
+version: 1.5.0
 
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead


### PR DESCRIPTION
Fixes #85 , #88 

I renamed the SuggestionsBoxController to just SuggestionsBox. I then created a new SuggestionsBoxController class that can be passed to TypeAheadField. This new controller class will allow you to manually open, close, toggle, or resize the suggestions box.

I think this is a good way to fix the animations problem we have, but what do you guys think?

Also increased the delay to 150 ms to fix TypeAheadField in dialogs. Currently we cannot manually call resize for dialogs since we can't catch when that animation ends.