### PR TITLE
Fix returning null on suggestionsCallback

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1029,7 +1029,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         // if it wasn't removed in the meantime
         setState(() {
           double animationStart = widget.animationStart;
-          if (error != null || suggestions.length == 0) {
+          if (error != null || suggestions == null || suggestions.length == 0) {
             animationStart = 1.0;
           }
           this._animationController.forward(from: animationStart);


### PR DESCRIPTION
Allows returning null on suggestionsCallback. Returning null will not show the suggestions box at all.