### PR TITLE
refactor!: expect suggestions as Iterable instead of List

### DIFF
--- a/lib/cupertino_flutter_typeahead.dart
+++ b/lib/cupertino_flutter_typeahead.dart
@@ -23,7 +23,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 
-typedef FutureOr<List<T>> SuggestionsCallback<T>(String pattern);
+typedef FutureOr<Iterable<T>> SuggestionsCallback<T>(String pattern);
 typedef Widget ItemBuilder<T>(BuildContext context, T itemData);
 typedef void SuggestionSelectionCallback<T>(T suggestion);
 typedef Widget ErrorBuilder(BuildContext context, Object error);
@@ -796,7 +796,7 @@ class _SuggestionsList<T> extends StatefulWidget {
 
 class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
     with SingleTickerProviderStateMixin {
-  List<T> _suggestions;
+  Iterable<T> _suggestions;
   VoidCallback _controllerListener;
   Timer _debounceTimer;
   bool _isLoading, _isQueued;
@@ -857,7 +857,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         this._error = null;
       });
 
-      List<T> suggestions = [];
+      Iterable<T> suggestions = [];
       Object error;
 
       final Object callbackIdentity = Object();
@@ -876,7 +876,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         // if it wasn't removed in the meantime
         setState(() {
           double animationStart = widget.animationStart;
-          if (error != null || suggestions == null || suggestions.length == 0) {
+          if (error != null || suggestions == null || suggestions.isEmpty) {
             animationStart = 1.0;
           }
           this._animationController.forward(from: animationStart);
@@ -914,7 +914,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       } else {
         child = createErrorWidget();
       }
-    } else if (this._suggestions.length == 0) {
+    } else if (this._suggestions.isEmpty) {
       if (widget.hideOnEmpty) {
         child = Container(height: 0);
       } else {

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -233,7 +233,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 
-typedef FutureOr<List<T>> SuggestionsCallback<T>(String pattern);
+typedef FutureOr<Iterable<T>> SuggestionsCallback<T>(String pattern);
 typedef Widget ItemBuilder<T>(BuildContext context, T itemData);
 typedef void SuggestionSelectionCallback<T>(T suggestion);
 typedef Widget ErrorBuilder(BuildContext context, Object error);
@@ -985,7 +985,7 @@ class _SuggestionsList<T> extends StatefulWidget {
 
 class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
     with SingleTickerProviderStateMixin {
-  List<T> _suggestions;
+  Iterable<T> _suggestions;
   VoidCallback _controllerListener;
   Timer _debounceTimer;
   bool _isLoading, _isQueued;
@@ -1046,7 +1046,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         this._error = null;
       });
 
-      List<T> suggestions = [];
+      Iterable<T> suggestions = [];
       Object error;
 
       final Object callbackIdentity = Object();
@@ -1065,7 +1065,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         // if it wasn't removed in the meantime
         setState(() {
           double animationStart = widget.animationStart;
-          if (error != null || suggestions == null || suggestions.length == 0) {
+          if (error != null || suggestions == null || suggestions.isEmpty) {
             animationStart = 1.0;
           }
           this._animationController.forward(from: animationStart);
@@ -1103,7 +1103,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       } else {
         child = createErrorWidget();
       }
-    } else if (this._suggestions.length == 0) {
+    } else if (this._suggestions.isEmpty) {
       if (widget.hideOnEmpty) {
         child = Container(height: 0);
       } else {


### PR DESCRIPTION
_BREAKING CHANGE: changing type allows for more fine grained performance optimizations, but may break existing implementations_

---

I believe this allows for more flexibility when generating the suggestions.

As your code does not rely on any `List` specific features, I went ahead and made the changes.

Here's a quick example for a `SuggestionsCallback` that would make use of this:

```dart
  Iterable<LocationModel> _getFilteredLocations([String pattern = '']) {
    if (pattern?.isEmpty ?? true) return locations;

    var lcPattern = pattern.toLowerCase();

    // `this.locations` is a (potentially very large) Iterable holding location information.
    // as the result set might also be very large, not having to do `.toList()` can be a noticeable performance improvement in regards to memory use & execution time
    return this.locations.where((l) => l.name.toLowerCase().contains(lcPattern));
  }
```