### PR TITLE
Fix onChange and onSubmitted callbacks not getting called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0 - 01/03/2020
+
+- Fix `onChange` and `onSubmitted` callbacks of `TextFormFieldConfiguration`
+
 ## 1.8.0 - 23/01/2020
 
 - Change from List to Iterable for flexibility

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -7,3 +7,4 @@
 build/
 
 .flutter-plugins
+.flutter-plugins-dependencies

--- a/example/ios/.gitignore
+++ b/example/ios/.gitignore
@@ -39,6 +39,7 @@ Icon?
 /Flutter/App.framework
 /Flutter/Flutter.framework
 /Flutter/Generated.xcconfig
+/Flutter/flutter_export_environment.sh
 /ServiceDefinitions.json
 
 Pods/

--- a/example/lib/cupertino_app.dart
+++ b/example/lib/cupertino_app.dart
@@ -63,9 +63,7 @@ class _FavoriteCitiesPage extends State<FavoriteCitiesPage> {
                 _typeAheadController.text = suggestion;
               },
               validator: (value) {
-                if (value.isEmpty) {
-                  return 'Please select a city';
-                }
+                return (value.isEmpty) ? 'Please select a city' : null;
               },
             ),
             SizedBox(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:example/material_app.dart';
-import 'package:example/cupertino_app.dart';
+// import 'package:example/cupertino_app.dart';
 
 void main() => runApp(MyMaterialApp());
 //void main() => runApp(MyCupertinoApp());

--- a/example/lib/material_app.dart
+++ b/example/lib/material_app.dart
@@ -132,7 +132,7 @@ class _FormExampleState extends State<FormExample> {
                   this._formKey.currentState.save();
                   Scaffold.of(context).showSnackBar(SnackBar(
                       content:
-                      Text('Your Favorite City is ${this._selectedCity}')));
+                          Text('Your Favorite City is ${this._selectedCity}')));
                 }
               },
             )
@@ -150,10 +150,11 @@ class ScrollExample extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListView(children: [
       Center(
-          child: Padding(
-            padding: const EdgeInsets.all(8.0),
-            child: Text("Suggestion box will resize when scrolling"),
-          )),
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text("Suggestion box will resize when scrolling"),
+        ),
+      ),
       SizedBox(height: 200),
       TypeAheadField<String>(
         getImmediateSuggestions: true,
@@ -165,7 +166,7 @@ class ScrollExample extends StatelessWidget {
         suggestionsCallback: (String pattern) async {
           return items
               .where((item) =>
-              item.toLowerCase().startsWith(pattern.toLowerCase()))
+                  item.toLowerCase().startsWith(pattern.toLowerCase()))
               .toList();
         },
         itemBuilder: (context, String suggestion) {

--- a/example/lib/material_app.dart
+++ b/example/lib/material_app.dart
@@ -116,9 +116,7 @@ class _FormExampleState extends State<FormExample> {
                 this._typeAheadController.text = suggestion;
               },
               validator: (value) {
-                if (value.isEmpty) {
-                  return 'Please select a city';
-                }
+                return (value.isEmpty) ? 'Please select a city' : null;
               },
               onSaved: (value) => this._selectedCity = value,
             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.11"
   args:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.6.1"
+    version: "1.8.0"
   image:
     dependency: transitive
     description:
@@ -101,14 +101,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.5"
+    version: "0.12.6"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7"
+    version: "1.1.8"
   path:
     dependency: transitive
     description:
@@ -183,7 +183,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.5"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.8.0"
+    version: "2.0.0"
   image:
     dependency: transitive
     description:

--- a/lib/cupertino_flutter_typeahead.dart
+++ b/lib/cupertino_flutter_typeahead.dart
@@ -574,9 +574,11 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
       this._focusNode = FocusNode();
     }
 
-    this._suggestionsBox = _CupertinoSuggestionsBox(context, widget.direction, widget.autoFlipDirection);
+    this._suggestionsBox = _CupertinoSuggestionsBox(
+        context, widget.direction, widget.autoFlipDirection);
     widget.suggestionsBoxController?._suggestionsBox = this._suggestionsBox;
-    widget.suggestionsBoxController?._effectiveFocusNode = this._effectiveFocusNode;
+    widget.suggestionsBoxController?._effectiveFocusNode =
+        this._effectiveFocusNode;
 
     this._focusNodeListener = () {
       if (_effectiveFocusNode.hasFocus) {
@@ -1111,7 +1113,7 @@ class CupertinoSuggestionsBoxDecoration {
     this.color,
     this.border,
     this.borderRadius,
-    this.offsetX: 0.0
+    this.offsetX: 0.0,
   });
 }
 

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1286,7 +1286,7 @@ class SuggestionsBoxDecoration {
 
 /// Supply an instance of this class to the [TypeAhead.textFieldConfiguration]
 /// property to configure the displayed text field
-class TextFieldConfiguration<T> {
+class TextFieldConfiguration {
   /// The decoration to show around the text field.
   ///
   /// Same as [TextField.decoration](https://docs.flutter.io/flutter/material/TextField/decoration.html)
@@ -1390,13 +1390,13 @@ class TextFieldConfiguration<T> {
   /// Called when the text being edited changes.
   ///
   /// Same as [TextField.onChanged](https://docs.flutter.io/flutter/material/TextField/onChanged.html)
-  final ValueChanged<T> onChanged;
+  final ValueChanged<String> onChanged;
 
   /// Called when the user indicates that they are done editing the text in the
   /// field.
   ///
   /// Same as [TextField.onSubmitted](https://docs.flutter.io/flutter/material/TextField/onSubmitted.html)
-  final ValueChanged<T> onSubmitted;
+  final ValueChanged<String> onSubmitted;
 
   /// The color to use when painting the cursor.
   ///
@@ -1479,12 +1479,12 @@ class TextFieldConfiguration<T> {
 
   /// Copies the [TextFieldConfiguration] and only changes the specified
   /// properties
-  copyWith(
+  TextFieldConfiguration copyWith(
       {InputDecoration decoration,
       TextStyle style,
       TextEditingController controller,
-      ValueChanged<T> onChanged,
-      ValueChanged<T> onSubmitted,
+      ValueChanged<String> onChanged,
+      ValueChanged<String> onSubmitted,
       bool obscureText,
       bool maxLengthEnforced,
       int maxLength,

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -762,9 +762,11 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       this._focusNode = FocusNode();
     }
 
-    this._suggestionsBox = _SuggestionsBox(context, widget.direction, widget.autoFlipDirection);
+    this._suggestionsBox =
+        _SuggestionsBox(context, widget.direction, widget.autoFlipDirection);
     widget.suggestionsBoxController?._suggestionsBox = this._suggestionsBox;
-    widget.suggestionsBoxController?._effectiveFocusNode = this._effectiveFocusNode;
+    widget.suggestionsBoxController?._effectiveFocusNode =
+        this._effectiveFocusNode;
 
     this._focusNodeListener = () {
       if (_effectiveFocusNode.hasFocus) {
@@ -790,7 +792,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
         this._initOverlayEntry();
         // calculate initial suggestions list size
         this._suggestionsBox.resize();
-        
+
         // in case we already missed the focus event
         if (this._effectiveFocusNode.hasFocus) {
           this._suggestionsBox.open();
@@ -1362,7 +1364,7 @@ class TextFieldConfiguration<T> {
   ///
   /// Same as [TextField.maxLines](https://docs.flutter.io/flutter/material/TextField/maxLines.html)
   final int maxLines;
-  
+
   /// The minimum number of lines to occupy when the content spans fewer lines.
   ///
   /// Same as [TextField.minLines](https://docs.flutter.io/flutter/material/TextField/minLines.html)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_typeahead
-version: 1.8.0
+version: 2.0.0
 
 description: A highly customizable typeahead (autocomplete) text input field for Flutter
 homepage: https://github.com/AbdulRahmanAlHamali/flutter_typeahead
@@ -17,7 +17,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 environment:
-  sdk: '>=1.19.0 <3.0.0'
+  sdk: ">=1.19.0 <3.0.0"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
Fixes `onChange` and `onSubmitted` not getting called when `TextFieldConfiguration` generic type is different than `dynamic`.

`TextFieldConfiguration` in `TypeAheadFormField` had no generic type specified so the callbacks had types `(dynamic) => void/Null`. When typed `TextFieldConfiguration<String>` was assigned to it had callbacks of type `(String) => void/Null` which caused runtime type error `_TypeError (type '(String) => Null' is not a subtype of type '(dynamic) => void')`.

Actually `TextFieldConfiguration` shouldn't be generic at all since `TextField` always expects callbacks with `String` arguments.