### PR TITLE
feature: Support customize suggestions box clip behavior

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1145,6 +1145,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       shape: widget.decoration.shape,
       borderRadius: widget.decoration.borderRadius,
       shadowColor: widget.decoration.shadowColor,
+      clipBehavior: widget.decoration.clipBehavior,
       child: ConstrainedBox(
         constraints: constraints,
         child: animationChild,
@@ -1268,6 +1269,11 @@ class SuggestionsBoxDecoration {
   /// Adds an offset to the suggestions box
   final double offsetX;
 
+  /// The content will be clipped (or not) according to this option.
+  ///
+  /// Same as [Material.clipBehavior](https://api.flutter.dev/flutter/material/Material/clipBehavior.html)
+  final Clip clipBehavior;
+
   /// Creates a SuggestionsBoxDecoration
   const SuggestionsBoxDecoration(
       {this.elevation: 4.0,
@@ -1277,6 +1283,7 @@ class SuggestionsBoxDecoration {
       this.borderRadius,
       this.shadowColor: const Color(0xFF000000),
       this.constraints,
+      this.clipBehavior: Clip.none,
       this.offsetX: 0.0})
       : assert(shadowColor != null),
         assert(elevation != null);


### PR DESCRIPTION
I found that if a borderRadius set to the suggestions box, the widget built by itemBuilder will keep display outside the box when scrolling.
![IMG_0014](https://user-images.githubusercontent.com/26702359/79851045-5f76bf80-83f7-11ea-82ea-7cfabc9d6c5c.PNG)

