### PR TITLE
Added default to autovalidateMode

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -259,12 +259,12 @@ class TypeAheadFormField<T> extends FormField<String> {
       {Key key,
       String initialValue,
       bool getImmediateSuggestions: false,
-      @Deprecated('Use autoValidateMode parameter which provides more specific '
+      @Deprecated('Use autovalidateMode parameter which provides more specific '
           'behavior related to auto validation. '
           'This feature was deprecated after Flutter v1.19.0.')
           bool autovalidate: false,
       bool enabled: true,
-      AutovalidateMode autovalidateMode,
+      AutovalidateMode autovalidateMode: AutovalidateMode.disabled,
       FormFieldSetter<String> onSaved,
       FormFieldValidator<String> validator,
       ErrorBuilder errorBuilder,


### PR DESCRIPTION
* [FormField](https://api.flutter.dev/flutter/widgets/FormField-class.html) defaults [`autovalidateMode`](https://api.flutter.dev/flutter/widgets/FormField/autovalidateMode.html) to be `AutovalidateMode.disabled`
* Also corrected the _deprecation message_ for `autovalidate`
