### PR TITLE
Removed unecessary generic type from TextFieldConfiguration

### DIFF
--- a/lib/cupertino_flutter_typeahead.dart
+++ b/lib/cupertino_flutter_typeahead.dart
@@ -1142,7 +1142,7 @@ class CupertinoSuggestionsBoxDecoration {
 /// Supply an instance of this class to the [TypeAhead.textFieldConfiguration]
 /// property to configure the displayed text field. See [documentation](https://docs.flutter.io/flutter/cupertino/CupertinoTextField-class.html)
 /// for more information on properties.
-class CupertinoTextFieldConfiguration<T> {
+class CupertinoTextFieldConfiguration {
   final TextEditingController controller;
   final FocusNode focusNode;
   final BoxDecoration decoration;

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1322,7 +1322,7 @@ class SuggestionsBoxDecoration {
 
 /// Supply an instance of this class to the [TypeAhead.textFieldConfiguration]
 /// property to configure the displayed text field
-class TextFieldConfiguration<T> {
+class TextFieldConfiguration {
   /// The decoration to show around the text field.
   ///
   /// Same as [TextField.decoration](https://docs.flutter.io/flutter/material/TextField/decoration.html)
@@ -1431,13 +1431,13 @@ class TextFieldConfiguration<T> {
   /// Called when the text being edited changes.
   ///
   /// Same as [TextField.onChanged](https://docs.flutter.io/flutter/material/TextField/onChanged.html)
-  final ValueChanged<T> onChanged;
+  final ValueChanged<String> onChanged;
 
   /// Called when the user indicates that they are done editing the text in the
   /// field.
   ///
   /// Same as [TextField.onSubmitted](https://docs.flutter.io/flutter/material/TextField/onSubmitted.html)
-  final ValueChanged<T> onSubmitted;
+  final ValueChanged<String> onSubmitted;
 
   /// The color to use when painting the cursor.
   ///
@@ -1525,8 +1525,8 @@ class TextFieldConfiguration<T> {
       {InputDecoration decoration,
       TextStyle style,
       TextEditingController controller,
-      ValueChanged<T> onChanged,
-      ValueChanged<T> onSubmitted,
+      ValueChanged<String> onChanged,
+      ValueChanged<String> onSubmitted,
       bool obscureText,
       bool maxLengthEnforced,
       int maxLength,


### PR DESCRIPTION
Remove unecessary Generic type from TextFieldConfiguration and changed ValueChanged<T> to ValueChanged<String> from onChanged and onSubmitted for TextField callbacks