### PR TITLE
fix race condition by correctly awaiting results.

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1072,7 +1072,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
 
   Future<void> invalidateSuggestions() async {
     _suggestionsValid = false;
-    _getSuggestions();
+    await _getSuggestions();
   }
 
   Future<void> _getSuggestions() async {


### PR DESCRIPTION
When a user changes the text while a network request is running the new search will not be triggered, because of a missing `await`.

imho this is still not perfect, because it should discard old searched altogether, but that would be a bigger change. But this change fixes the current behavior.