### PR TITLE
Cancel the debounce timer when widget is disposed

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1105,6 +1105,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T?>>
   @override
   void dispose() {
     _animationController!.dispose();
+    _debounceTimer?.cancel();
     super.dispose();
   }
 

--- a/test/flutter_typeahead_test.dart
+++ b/test/flutter_typeahead_test.dart
@@ -73,4 +73,9 @@ void main() {
     expect(find.text('Type Ahead'), findsOneWidget);
     expect(find.text('Default text'), findsOneWidget);
   });
+
+  testWidgets('entering text works', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: TestPage()));
+    await tester.enterText(find.byType(TypeAheadFormField), 'new text');
+  });
 }


### PR DESCRIPTION
Without canceling the timer, an exception was thrown when the widget was disposed. This was immediately happening in flutter widget tests because they are typically done faster than the 300 ms debounce timer.

This is resolving #213 