### PR TITLE
Check if the overlay is opened

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1788,6 +1788,10 @@ class SuggestionsBoxController {
   void open() {
     _effectiveFocusNode!.requestFocus();
   }
+    
+  bool isOpened() {
+    return _suggestionsBox!.isOpened;
+  }
 
   /// Closes the suggestions box
   void close() {


### PR DESCRIPTION
Check if the overlay is opened, situations like `WillPopScope` we might want to close just the overlay, instead of the whole `Widget`