### PR TITLE
Guard against missing size in _adjustMaxHeightAndOrientation

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1670,7 +1670,11 @@ class _SuggestionsBox {
   void _adjustMaxHeightAndOrientation() {
     TypeAheadField widget = context.widget as TypeAheadField;
 
-    RenderBox box = context.findRenderObject() as RenderBox;
+    RenderBox? box = context.findRenderObject() as RenderBox?;
+    if (box == null || box.hasSize == false) {
+      return;
+    }
+
     textBoxWidth = box.size.width;
     textBoxHeight = box.size.height;
 
@@ -1789,7 +1793,7 @@ class SuggestionsBoxController {
   void open() {
     _effectiveFocusNode!.requestFocus();
   }
-    
+
   bool isOpened() {
     return _suggestionsBox!.isOpened;
   }


### PR DESCRIPTION
When the TypeAheadField was rendered on a screen that was in a NavigationStack and another Screen was rendered on top of it, it was throwing exceptions because the rendered box did not have a size. Now the resizing only happens if the Box was found and has a size.

This resolves #160 