### PR TITLE
Simple important Fix: Issue 288

### DIFF
--- a/lib/cupertino_flutter_typeahead.dart
+++ b/lib/cupertino_flutter_typeahead.dart
@@ -911,8 +911,9 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
 
   @override
   Widget build(BuildContext context) {
-    if (this._suggestions == null && this._isLoading == false)
-      return Container();
+    bool noSuggestions =
+        this._suggestions == null || this._suggestions?.length == 0;
+    if (noSuggestions && this._isLoading == false) return Container();
 
     Widget child;
     if (this._isLoading) {

--- a/lib/cupertino_flutter_typeahead.dart
+++ b/lib/cupertino_flutter_typeahead.dart
@@ -911,9 +911,10 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
 
   @override
   Widget build(BuildContext context) {
-    bool noSuggestions =
-        this._suggestions == null || this._suggestions?.length == 0;
-    if (noSuggestions && this._isLoading == false) return Container();
+    bool isEmpty =
+        this._suggestions?.length == 0 && widget.controller!.text == "";
+    if ((this._suggestions == null || isEmpty) && this._isLoading == false)
+      return Container();
 
     Widget child;
     if (this._isLoading) {

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1093,9 +1093,10 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
 
   @override
   Widget build(BuildContext context) {
-    bool noSuggestions =
-        this._suggestions == null || this._suggestions?.length == 0;
-    if (noSuggestions && this._isLoading == false) return Container();
+    bool isEmpty =
+        this._suggestions?.length == 0 && widget.controller!.text == "";
+    if ((this._suggestions == null || isEmpty) && this._isLoading == false)
+      return Container();
 
     Widget child;
     if (this._isLoading) {

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1093,8 +1093,9 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
 
   @override
   Widget build(BuildContext context) {
-    if (this._suggestions == null && this._isLoading == false)
-      return Container();
+    bool noSuggestions =
+        this._suggestions == null || this._suggestions?.length == 0;
+    if (noSuggestions && this._isLoading == false) return Container();
 
     Widget child;
     if (this._isLoading) {


### PR DESCRIPTION
Fixed the issue, that caused "No result found" to be shown even if no search string was entered:
https://github.com/AbdulRahmanAlHamali/flutter_typeahead/issues/288