### PR TITLE
Allow suggestionsCallback to return null

### DIFF
--- a/lib/cupertino_flutter_typeahead.dart
+++ b/lib/cupertino_flutter_typeahead.dart
@@ -887,7 +887,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         this._error = null;
       });
 
-      Iterable<T> suggestions = [];
+      Iterable<T>? suggestions;
       Object? error;
 
       try {
@@ -901,7 +901,8 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         // if it wasn't removed in the meantime
         setState(() {
           double? animationStart = widget.animationStart;
-          if (error != null || suggestions.isEmpty) {
+          // allow suggestionsCallback to return null and not throw error here
+          if (error != null || suggestions?.isEmpty == true) {
             animationStart = 1.0;
           }
           this._animationController!.forward(from: animationStart);

--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -1075,7 +1075,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         this._error = null;
       });
 
-      Iterable<T> suggestions = [];
+      Iterable<T>? suggestions;
       Object? error;
 
       try {
@@ -1089,7 +1089,8 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         // if it wasn't removed in the meantime
         setState(() {
           double? animationStart = widget.animationStart;
-          if (error != null || suggestions.isEmpty) {
+            // allow suggestionsCallback to return null and not throw error here
+          if (error != null || suggestions?.isEmpty == true) {
             animationStart = 1.0;
           }
           this._animationController!.forward(from: animationStart);


### PR DESCRIPTION
If suggestionsCallback returns null (for example - we don't want to display anything when there is less then 3 characters typed) then the code below crashes.

`suggestions.isEmpty`

This PR fixes that, allowing suggestions to be nullable