### PR TITLE
Fix Scrollbar ScrollController

### DIFF
--- a/lib/flutter_typeahead.dart
+++ b/lib/flutter_typeahead.dart
@@ -998,6 +998,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
   Object? _error;
   AnimationController? _animationController;
   String? _lastTextValue;
+  late final _scrollController = ScrollController();
 
   _SuggestionsListState() {
     this._controllerListener = () {
@@ -1235,6 +1236,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       padding: EdgeInsets.zero,
       primary: false,
       shrinkWrap: true,
+      controller: _scrollController,
       reverse: widget.suggestionsBox!.direction == AxisDirection.down
           ? false
           : true, // reverses the list to start at the bottom
@@ -1249,7 +1251,10 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
     );
 
     if (widget.decoration!.hasScrollbar) {
-      child = Scrollbar(child: child);
+      child = Scrollbar(
+        controller: _scrollController,
+        child: child,
+      );
     }
 
     return child;


### PR DESCRIPTION
When using a non primary scrollview and a scrollbar, we need to provide the same scroll controller to both of these widgets. Otherwise the scrollbar will obtain the PrimaryScrollController and it won't match the one in the ScrollView.
Newer versions of Flutter (not yet in stable or beta) warn about this situation, so this fix will be required in the future. 