### PR TITLE
de private

### DIFF
--- a/lib/src/cupertino_flutter_typeahead.dart
+++ b/lib/src/cupertino_flutter_typeahead.dart
@@ -108,8 +108,8 @@ class CupertinoTypeAheadFormField<T> extends FormField<String> {
             enabled: enabled,
             autovalidateMode: autovalidateMode,
             builder: (FormFieldState<String> field) {
-              final _CupertinoTypeAheadFormFieldState state =
-                  field as _CupertinoTypeAheadFormFieldState<dynamic>;
+              final CupertinoTypeAheadFormFieldState state =
+                  field as CupertinoTypeAheadFormFieldState<dynamic>;
 
               return CupertinoTypeAheadField(
                 getImmediateSuggestions: getImmediateSuggestions,
@@ -146,11 +146,11 @@ class CupertinoTypeAheadFormField<T> extends FormField<String> {
             });
 
   @override
-  _CupertinoTypeAheadFormFieldState<T> createState() =>
-      _CupertinoTypeAheadFormFieldState<T>();
+  CupertinoTypeAheadFormFieldState<T> createState() =>
+      CupertinoTypeAheadFormFieldState<T>();
 }
 
-class _CupertinoTypeAheadFormFieldState<T> extends FormFieldState<String> {
+class CupertinoTypeAheadFormFieldState<T> extends FormFieldState<String> {
   TextEditingController? _controller;
 
   TextEditingController? get _effectiveController =>


### PR DESCRIPTION
Hi @sjmcdowall

I'm trying to build the wrapper package based on your awesome `flutter_typeahead` to use with `reactive_forms`.

While I'm re-exporting the package I'm getting errors during the build.

```
Xcode's output:
↳
    ../../../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_typeahead-3.2.1/lib/src/cupertino_flutter_typeahead.dart:149:3: Error: Type '_CupertinoTypeAheadFormFieldState' not found.
      _CupertinoTypeAheadFormFieldState<T> createState() =>
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ../../../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_typeahead-3.2.1/lib/src/cupertino_flutter_typeahead.dart:149:3: Error: Expected 0 type arguments.
      _CupertinoTypeAheadFormFieldState<T> createState() =>
      ^
    ../../../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_typeahead-3.2.1/lib/src/cupertino_flutter_typeahead.dart:111:21: Error: '_CupertinoTypeAheadFormFieldState' isn't a type.
                  final _CupertinoTypeAheadFormFieldState state =
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ../../../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_typeahead-3.2.1/lib/src/cupertino_flutter_typeahead.dart:112:28: Error: '_CupertinoTypeAheadFormFieldState' isn't a type.
                      field as _CupertinoTypeAheadFormFieldState<dynamic>;
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ../../../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_typeahead-3.2.1/lib/src/cupertino_flutter_typeahead.dart:150:7: Error: The method '_CupertinoTypeAheadFormFieldState' isn't defined for the class 'CupertinoTypeAheadFormField<T>'.
     - 'CupertinoTypeAheadFormField' is from 'package:flutter_typeahead/src/cupertino_flutter_typeahead.dart' ('../../../../../flutter/.pub-cache/hosted/pub.dartlang.org/flutter_typeahead-3.2.1/lib/src/cupertino_flutter_typeahead.dart').
    Try correcting the name to the name of an existing method, or defining a method named '_CupertinoTypeAheadFormFieldState'.
          _CupertinoTypeAheadFormFieldState<T>();
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```