### PR TITLE
Add option for min number of chars before suggestionsCallback is called

### DIFF
--- a/test/flutter_typeahead_test.dart
+++ b/test/flutter_typeahead_test.dart
@@ -5,7 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 
 class TestPage extends StatefulWidget {
-  TestPage({Key? key}) : super(key: key);
+  final int minCharsForSuggestions;
+  TestPage({Key? key, this.minCharsForSuggestions: 0}) : super(key: key);
 
   @override
   State<StatefulWidget> createState() => TestPageState();
@@ -40,25 +41,27 @@ class TestPageState extends State<TestPage> {
             padding: EdgeInsets.symmetric(horizontal: 16.0),
             children: [
               TypeAheadFormField<String>(
-                  textFieldConfiguration: TextFieldConfiguration(
-                      autofocus: true,
-                      inputFormatters: [LengthLimitingTextInputFormatter(50)],
-                      controller: _controller,
-                      decoration: InputDecoration(labelText: 'Type Ahead')),
-                  suggestionsCallback: (pattern) {
-                    if (pattern.length > 0)
-                      return [pattern + 'aaa', pattern + 'bbb'];
-                    else
-                      return [];
-                  },
-                  noItemsFoundBuilder: (context) => const SizedBox(),
-                  itemBuilder: (context, String suggestion) {
-                    return ListTile(
-                      title: Text(suggestion),
-                    );
-                  },
-                  onSuggestionSelected: (String suggestion) =>
-                      this._controller.text = suggestion),
+                textFieldConfiguration: TextFieldConfiguration(
+                    autofocus: true,
+                    inputFormatters: [LengthLimitingTextInputFormatter(50)],
+                    controller: _controller,
+                    decoration: InputDecoration(labelText: 'Type Ahead')),
+                suggestionsCallback: (pattern) {
+                  if (pattern.length > 0)
+                    return [pattern + 'aaa', pattern + 'bbb'];
+                  else
+                    return [];
+                },
+                noItemsFoundBuilder: (context) => const SizedBox(),
+                itemBuilder: (context, String suggestion) {
+                  return ListTile(
+                    title: Text(suggestion),
+                  );
+                },
+                onSuggestionSelected: (String suggestion) =>
+                    this._controller.text = suggestion,
+                minCharsForSuggestions: widget.minCharsForSuggestions,
+              ),
             ],
           ),
         ));
@@ -66,7 +69,9 @@ class TestPageState extends State<TestPage> {
 }
 
 class CupertinoTestPage extends StatefulWidget {
-  CupertinoTestPage({Key? key}) : super(key: key);
+  final int minCharsForSuggestions;
+  CupertinoTestPage({Key? key, this.minCharsForSuggestions: 0})
+      : super(key: key);
 
   @override
   State<StatefulWidget> createState() => CupertinoTestPageState();
@@ -117,7 +122,8 @@ class CupertinoTestPageState extends State<CupertinoTestPage> {
                     return Text(suggestion);
                   },
                   onSuggestionSelected: (String suggestion) =>
-                      this._controller.text = suggestion),
+                      this._controller.text = suggestion,
+                  minCharsForSuggestions: widget.minCharsForSuggestions),
             ],
           ),
         ));
@@ -149,6 +155,23 @@ void main() {
       expect(find.text("test2aaa"), findsOneWidget);
       expect(find.text("test2bbb"), findsOneWidget);
     });
+
+    testWidgets('min chars for suggestions', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+          home: TestPage(
+        minCharsForSuggestions: 4,
+      )));
+      await tester.pumpAndSettle();
+
+      tester.testTextInput.enterText("333");
+      await tester.pumpAndSettle(Duration(milliseconds: 2000));
+      expect(find.text("333aaa"), findsNothing);
+      expect(find.text("333bbb"), findsNothing);
+      tester.testTextInput.enterText("4444");
+      await tester.pumpAndSettle(Duration(milliseconds: 2000));
+      expect(find.text("4444aaa"), findsOneWidget);
+      expect(find.text("4444bbb"), findsOneWidget);
+    });
     // testWidgets('entering text works', (WidgetTester tester) async {
     //   await tester.pumpWidget(MaterialApp(home: TestPage()));
     //   await tester.pumpAndSettle();
@@ -177,6 +200,23 @@ void main() {
       expect(find.text("testbbb"), findsNothing);
       expect(find.text("test2aaa"), findsOneWidget);
       expect(find.text("test2bbb"), findsOneWidget);
+    });
+
+    testWidgets('min chars for suggestions', (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialApp(
+          home: TestPage(
+        minCharsForSuggestions: 4,
+      )));
+      await tester.pumpAndSettle();
+
+      tester.testTextInput.enterText("333");
+      await tester.pumpAndSettle(Duration(milliseconds: 2000));
+      expect(find.text("333aaa"), findsNothing);
+      expect(find.text("333bbb"), findsNothing);
+      tester.testTextInput.enterText("4444");
+      await tester.pumpAndSettle(Duration(milliseconds: 2000));
+      expect(find.text("4444aaa"), findsOneWidget);
+      expect(find.text("4444bbb"), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Adds an explicit option to the typeahead fields which allows specifying how many characters need to be entered before the suggestionsCallback is called.