### PR TITLE
make maxLines nullable

### DIFF
--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -1404,7 +1404,7 @@ class TextFieldConfiguration {
   /// The maximum number of lines for the text to span, wrapping if necessary.
   ///
   /// Same as [TextField.maxLines](https://docs.flutter.io/flutter/material/TextField/maxLines.html)
-  final int maxLines;
+  final int? maxLines;
 
   /// The minimum number of lines to occupy when the content spans fewer lines.
   ///


### PR DESCRIPTION
the `maxLine` property in a normal `TextField` can be `null` to allow infinite lines.

This PR also makes this possible for the `TypeAheadField`.