### PR TITLE
Punctuation typos fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,21 +8,21 @@ The easiest way to get involved is to create a [new issue](https://github.com/Ab
 
 If you plan to submit a PR please do the following:
 
-- Fork the repository
+- Fork the repository.
 - Create a feature branch from the **develop** branch!
-- Following the coding guidlines below
+- Following the coding guidelines below.
 - Submit the PR against the **develop** branch.
-- Update both Material and Cupertino code if applicable
+- Update both Material and Cupertino code if applicable.
 
-## General coding guidlines
+## General coding guidelines
 
 If you'd like to add a feature or fix a bug, we're more than happy to accept pull requests! We only ask a few things:
 
 - Ensure your code contains no analyzer errors, e.g.
-  - Code is strong-mode compliant
-  - Code is free of lint errors
-- Format your code with `dartfmt`
-- Write helpful documentation
+  - Code is strong-mode compliant.
+  - Code is free of lint errors.
+- Format your code with `dartfmt`.
+- Write helpful documentation.
 - If you would like to make a bigger / fundamental change to the codebase, please file a lightweight example PR / issue.
 
 ## Before Uploading

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ If you plan to submit a PR please do the following:
 
 If you'd like to add a feature or fix a bug, we're more than happy to accept pull requests! We only ask a few things:
 
-- Ensure your code contains no analyzer errors, e.g.
+- Ensure your code contains no analyzer errors, e.g:
   - Code is strong-mode compliant.
   - Code is free of lint errors.
 - Format your code with `dartfmt`.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,12 @@ users as they type.
 
 ## Features
 * Shows suggestions in an overlay that floats on top of other widgets.
-* Allows you to specify what the suggestions will look like through a
-builder function.
+* Allows you to specify what the suggestions will look like through a builder function.
 * Allows you to specify what happens when the user taps a suggestion.
-* Accepts all the parameters that traditional TextFields accept, like
-decoration, custom TextEditingController, text styling, etc.
+* Accepts all the parameters that traditional TextFields accept, like decoration, custom TextEditingController, text styling, etc.
 * Provides two versions, a normal version and a [FormField](https://docs.flutter.io/flutter/widgets/FormField-class.html)
 version that accepts validation, submitting, etc.
-* Provides high customizability; you can customize the suggestion box decoration,
-the loading bar, the animation, the debounce duration, etc.
+* Provides high customizability; you can customize the suggestion box decoration, the loading bar, the animation, the debounce duration, etc.
 
 ## Installation
 See the [installation instructions on pub](https://pub.dartlang.org/packages/flutter_typeahead#-installing-tab-).

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 # Flutter TypeAhead
 A TypeAhead (autocomplete) widget for Flutter, where you can show suggestions to
-users as they type
+users as they type.
 
 <img src="https://raw.githubusercontent.com/AbdulRahmanAlHamali/flutter_typeahead/master/flutter_typeahead.gif">
 
 ## Features
-* Shows suggestions in an overlay that floats on top of other widgets
+* Shows suggestions in an overlay that floats on top of other widgets.
 * Allows you to specify what the suggestions will look like through a
-builder function
-* Allows you to specify what happens when the user taps a suggestion
+builder function.
+* Allows you to specify what happens when the user taps a suggestion.
 * Accepts all the parameters that traditional TextFields accept, like
 decoration, custom TextEditingController, text styling, etc.
 * Provides two versions, a normal version and a [FormField](https://docs.flutter.io/flutter/widgets/FormField-class.html)
@@ -201,7 +201,7 @@ The Cupertino classes in TypeAhead are still new. There are also differences in 
 
 ## Customizations
 TypeAhead widgets consist of a TextField and a suggestion box that shows
-as the user types. Both are highly customizable
+as the user types. Both are highly customizable.
 
 ### Customizing the TextField
 You can customize the text field using the `textFieldConfiguration` property.


### PR DESCRIPTION
- Added **full stop (.)** punctuaction mark where needed.
- Corrected/ fixed typo: `guidline` to `guideline`.