### PR TITLE
Fix maxLengthEnforced deprecation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 
 .packages
 .pub/
+.flutter-plugins
+.flutter-plugins-dependencies
 
 build/
 example/.flutter-plugins*

--- a/lib/src/cupertino_flutter_typeahead.dart
+++ b/lib/src/cupertino_flutter_typeahead.dart
@@ -743,7 +743,7 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
         maxLines: widget.textFieldConfiguration.maxLines,
         minLines: widget.textFieldConfiguration.minLines,
         maxLength: widget.textFieldConfiguration.maxLength,
-        maxLengthEnforced: widget.textFieldConfiguration.maxLengthEnforced,
+        maxLengthEnforcement: widget.textFieldConfiguration.maxLengthEnforcement,
         onChanged: widget.textFieldConfiguration.onChanged,
         onEditingComplete: widget.textFieldConfiguration.onEditingComplete,
         onTap: widget.textFieldConfiguration.onTap,
@@ -1176,7 +1176,7 @@ class CupertinoTextFieldConfiguration {
   final int maxLines;
   final int? minLines;
   final int? maxLength;
-  final bool maxLengthEnforced;
+  final MaxLengthEnforcement? maxLengthEnforcement;
   final ValueChanged<String>? onChanged;
   final VoidCallback? onEditingComplete;
   final GestureTapCallback? onTap;
@@ -1214,7 +1214,7 @@ class CupertinoTextFieldConfiguration {
     this.maxLines = 1,
     this.minLines,
     this.maxLength,
-    this.maxLengthEnforced = true,
+    this.maxLengthEnforcement,
     this.onChanged,
     this.onEditingComplete,
     this.onTap,
@@ -1253,7 +1253,7 @@ class CupertinoTextFieldConfiguration {
     int? maxLines,
     int? minLines,
     int? maxLength,
-    bool? maxLengthEnforced,
+    MaxLengthEnforcement? maxLengthEnforcement,
     ValueChanged<String>? onChanged,
     VoidCallback? onEditingComplete,
     GestureTapCallback? onTap,
@@ -1290,7 +1290,7 @@ class CupertinoTextFieldConfiguration {
       maxLines: maxLines ?? this.maxLines,
       minLines: minLines ?? this.minLines,
       maxLength: maxLength ?? this.maxLength,
-      maxLengthEnforced: maxLengthEnforced ?? this.maxLengthEnforced,
+      maxLengthEnforcement: maxLengthEnforcement ?? this.maxLengthEnforcement,
       onChanged: onChanged ?? this.onChanged,
       onEditingComplete: onEditingComplete ?? this.onEditingComplete,
       onTap: onTap ?? this.onTap,

--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -933,7 +933,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
         textAlignVertical: widget.textFieldConfiguration.textAlignVertical,
         minLines: widget.textFieldConfiguration.minLines,
         maxLength: widget.textFieldConfiguration.maxLength,
-        maxLengthEnforced: widget.textFieldConfiguration.maxLengthEnforced,
+        maxLengthEnforcement: widget.textFieldConfiguration.maxLengthEnforcement,
         obscureText: widget.textFieldConfiguration.obscureText,
         onChanged: widget.textFieldConfiguration.onChanged,
         onSubmitted: widget.textFieldConfiguration.onSubmitted,
@@ -1451,8 +1451,8 @@ class TextFieldConfiguration {
   /// If true, prevents the field from allowing more than [maxLength]
   /// characters.
   ///
-  /// Same as [TextField.maxLengthEnforced](https://docs.flutter.io/flutter/material/TextField/maxLengthEnforced.html)
-  final bool maxLengthEnforced;
+  /// Same as [TextField.maxLengthEnforcement](https://api.flutter.dev/flutter/material/TextField/maxLengthEnforcement.html)
+  final MaxLengthEnforcement? maxLengthEnforcement;
 
   /// Whether to hide the text being edited (e.g., for passwords).
   ///
@@ -1525,7 +1525,7 @@ class TextFieldConfiguration {
     this.onChanged,
     this.onSubmitted,
     this.obscureText: false,
-    this.maxLengthEnforced: true,
+    this.maxLengthEnforcement,
     this.maxLength,
     this.maxLines: 1,
     this.minLines,
@@ -1560,7 +1560,7 @@ class TextFieldConfiguration {
       ValueChanged<String>? onChanged,
       ValueChanged<String>? onSubmitted,
       bool? obscureText,
-      bool? maxLengthEnforced,
+      MaxLengthEnforcement? maxLengthEnforcement,
       int? maxLength,
       int? maxLines,
       int? minLines,
@@ -1591,7 +1591,7 @@ class TextFieldConfiguration {
       onChanged: onChanged ?? this.onChanged,
       onSubmitted: onSubmitted ?? this.onSubmitted,
       obscureText: obscureText ?? this.obscureText,
-      maxLengthEnforced: maxLengthEnforced ?? this.maxLengthEnforced,
+      maxLengthEnforcement: maxLengthEnforcement ?? this.maxLengthEnforcement,
       maxLength: maxLength ?? this.maxLength,
       maxLines: maxLines ?? this.maxLines,
       minLines: minLines ?? this.minLines,

--- a/test/flutter_typeahead_test.dart
+++ b/test/flutter_typeahead_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Hello! This fixes the following deprecation, which has already committed in Flutter master. 
https://docs.flutter.dev/release/breaking-changes/use-maxLengthEnforcement-instead-of-maxLengthEnforced