### PR TITLE
Improved support for VoiceOver/TalkBack 

### DIFF
--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -263,6 +263,7 @@ class TypeAheadFormField<T> extends FormField<String> {
       ErrorBuilder? errorBuilder,
       WidgetBuilder? noItemsFoundBuilder,
       WidgetBuilder? loadingBuilder,
+      void Function(bool)? onSuggestionsBoxToggle,
       Duration debounceDuration: const Duration(milliseconds: 300),
       SuggestionsBoxDecoration suggestionsBoxDecoration:
           const SuggestionsBoxDecoration(),
@@ -321,6 +322,7 @@ class TypeAheadFormField<T> extends FormField<String> {
                 ),
                 suggestionsBoxVerticalOffset: suggestionsBoxVerticalOffset,
                 onSuggestionSelected: onSuggestionSelected,
+                onSuggestionsBoxToggle: onSuggestionsBoxToggle,
                 itemBuilder: itemBuilder,
                 suggestionsCallback: suggestionsCallback,
                 animationStart: animationStart,
@@ -676,36 +678,40 @@ class TypeAheadField<T> extends StatefulWidget {
   /// Defaults to 0.
   final int minCharsForSuggestions;
 
+  // Adds a callback for the suggestion box opening or closing
+  final void Function(bool)? onSuggestionsBoxToggle;
+
   /// Creates a [TypeAheadField]
-  TypeAheadField(
-      {Key? key,
-      required this.suggestionsCallback,
-      required this.itemBuilder,
-      required this.onSuggestionSelected,
-      this.textFieldConfiguration: const TextFieldConfiguration(),
-      this.suggestionsBoxDecoration: const SuggestionsBoxDecoration(),
-      this.debounceDuration: const Duration(milliseconds: 300),
-      this.suggestionsBoxController,
-      this.scrollController,
-      this.loadingBuilder,
-      this.noItemsFoundBuilder,
-      this.errorBuilder,
-      this.transitionBuilder,
-      this.animationStart: 0.25,
-      this.animationDuration: const Duration(milliseconds: 500),
-      this.getImmediateSuggestions: false,
-      this.suggestionsBoxVerticalOffset: 5.0,
-      this.direction: AxisDirection.down,
-      this.hideOnLoading: false,
-      this.hideOnEmpty: false,
-      this.hideOnError: false,
-      this.hideSuggestionsOnKeyboardHide: true,
-      this.keepSuggestionsOnLoading: true,
-      this.keepSuggestionsOnSuggestionSelected: false,
-      this.autoFlipDirection: false,
-      this.hideKeyboard: false,
-      this.minCharsForSuggestions: 0})
-      : assert(animationStart >= 0.0 && animationStart <= 1.0),
+  TypeAheadField({
+    Key? key,
+    required this.suggestionsCallback,
+    required this.itemBuilder,
+    required this.onSuggestionSelected,
+    this.textFieldConfiguration: const TextFieldConfiguration(),
+    this.suggestionsBoxDecoration: const SuggestionsBoxDecoration(),
+    this.debounceDuration: const Duration(milliseconds: 300),
+    this.suggestionsBoxController,
+    this.scrollController,
+    this.loadingBuilder,
+    this.noItemsFoundBuilder,
+    this.errorBuilder,
+    this.transitionBuilder,
+    this.animationStart: 0.25,
+    this.animationDuration: const Duration(milliseconds: 500),
+    this.getImmediateSuggestions: false,
+    this.suggestionsBoxVerticalOffset: 5.0,
+    this.direction: AxisDirection.down,
+    this.hideOnLoading: false,
+    this.hideOnEmpty: false,
+    this.hideOnError: false,
+    this.hideSuggestionsOnKeyboardHide: true,
+    this.keepSuggestionsOnLoading: true,
+    this.keepSuggestionsOnSuggestionSelected: false,
+    this.autoFlipDirection: false,
+    this.hideKeyboard: false,
+    this.minCharsForSuggestions: 0,
+    this.onSuggestionsBoxToggle,
+  })  : assert(animationStart >= 0.0 && animationStart <= 1.0),
         assert(
             direction == AxisDirection.down || direction == AxisDirection.up),
         assert(minCharsForSuggestions >= 0),
@@ -784,10 +790,12 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       if (_effectiveFocusNode!.hasFocus) {
         this._suggestionsBox!.open();
       } else {
-          if (widget.hideSuggestionsOnKeyboardHide){
-            this._suggestionsBox!.close();
-          }
+        if (widget.hideSuggestionsOnKeyboardHide){
+          this._suggestionsBox!.close();
+        }
       }
+
+      widget.onSuggestionsBoxToggle?.call(this._suggestionsBox!.isOpened);
     };
 
     this._effectiveFocusNode!.addListener(_focusNodeListener);
@@ -893,26 +901,45 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
         }
       }
 
-      return Positioned(
-        width: w,
-        child: CompositedTransformFollower(
-          link: this._layerLink,
-          showWhenUnlinked: false,
-          offset: Offset(
-              widget.suggestionsBoxDecoration.offsetX,
-              _suggestionsBox!.direction == AxisDirection.down
-                  ? _suggestionsBox!.textBoxHeight +
-                      widget.suggestionsBoxVerticalOffset
-                  : _suggestionsBox!.directionUpOffset),
-          child: _suggestionsBox!.direction == AxisDirection.down
-              ? suggestionsList
-              : FractionalTranslation(
-                  translation:
-                      Offset(0.0, -1.0), // visually flips list to go up
-                  child: suggestionsList,
-                ),
-        ),
+      final Widget compositedFollower = CompositedTransformFollower(
+        link: this._layerLink,
+        showWhenUnlinked: false,
+        offset: Offset(
+            widget.suggestionsBoxDecoration.offsetX,
+            _suggestionsBox!.direction == AxisDirection.down
+                ? _suggestionsBox!.textBoxHeight +
+                    widget.suggestionsBoxVerticalOffset
+                : _suggestionsBox!.directionUpOffset),
+        child: _suggestionsBox!.direction == AxisDirection.down
+            ? suggestionsList
+            : FractionalTranslation(
+                translation: Offset(0.0, -1.0), // visually flips list to go up
+                child: suggestionsList,
+              ),
       );
+
+      // When wrapped in the Positioned widget, the suggestions box widget
+      // is placed before the Scaffold semantically. In order to have the
+      // suggestions box navigable from the search input or keyboard,
+      // Semantics > Align > ConstrainedBox are needed. This does not change
+      // the style visually. However, when VO/TB are not enabled it is
+      // necessary to use the Positioned widget to allow the elements to be
+      // properly tappable.
+      return MediaQuery.of(context).accessibleNavigation
+          ? Semantics(
+              container: true,
+              child: Align(
+                alignment: Alignment.topLeft,
+                child: ConstrainedBox(
+                  constraints: BoxConstraints(maxWidth: w),
+                  child: compositedFollower,
+                ),
+              ),
+            )
+          : Positioned(
+              width: w,
+              child: compositedFollower,
+            );
     });
   }
 
@@ -935,7 +962,8 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
         textAlignVertical: widget.textFieldConfiguration.textAlignVertical,
         minLines: widget.textFieldConfiguration.minLines,
         maxLength: widget.textFieldConfiguration.maxLength,
-        maxLengthEnforcement: widget.textFieldConfiguration.maxLengthEnforcement,
+        maxLengthEnforcement:
+            widget.textFieldConfiguration.maxLengthEnforcement,
         obscureText: widget.textFieldConfiguration.obscureText,
         onChanged: widget.textFieldConfiguration.onChanged,
         onSubmitted: widget.textFieldConfiguration.onSubmitted,
@@ -1273,6 +1301,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       reverse: widget.suggestionsBox!.direction == AxisDirection.down
           ? false
           : true, // reverses the list to start at the bottom
+      semanticChildCount: this._suggestions?.length ?? 0,
       children: this._suggestions!.map((T suggestion) {
         return InkWell(
           child: widget.itemBuilder!(context, suggestion),


### PR DESCRIPTION
Description:
- When wrapped in the Positioned widget, the suggestions box widget is placed before the Scaffold semantically. In order to have the suggestions box navigable from the search input or keyboard, Semantics > Align > ConstrainedBox are needed. This does not change the style visually. However, when VO/TB are not enabled it is necessary to use the Positioned widget to allow the elements to be tappable.

Before:

https://user-images.githubusercontent.com/93152065/182159511-4e029790-35f1-434d-8ee1-f62318aacfec.mp4

After:

https://user-images.githubusercontent.com/93152065/182160154-c75739cc-e0ca-4c83-a53d-966b6992ce8a.MP4
