### PR TITLE
Adding hideKeyboardOnDrag option

### DIFF
--- a/lib/src/cupertino_flutter_typeahead.dart
+++ b/lib/src/cupertino_flutter_typeahead.dart
@@ -98,7 +98,8 @@ class CupertinoTypeAheadFormField<T> extends FormField<String> {
       bool keepSuggestionsOnLoading: true,
       bool keepSuggestionsOnSuggestionSelected: false,
       bool autoFlipDirection: false,
-      int minCharsForSuggestions: 0})
+      int minCharsForSuggestions: 0,
+      bool hideKeyboardOnDrag: false})
       : assert(
             initialValue == null || textFieldConfiguration.controller == null),
         assert(minCharsForSuggestions >= 0),
@@ -147,6 +148,7 @@ class CupertinoTypeAheadFormField<T> extends FormField<String> {
                     keepSuggestionsOnSuggestionSelected,
                 autoFlipDirection: autoFlipDirection,
                 minCharsForSuggestions: minCharsForSuggestions,
+                hideKeyboardOnDrag: hideKeyboardOnDrag,
               );
             });
 
@@ -480,6 +482,14 @@ class CupertinoTypeAheadField<T> extends StatefulWidget {
   ///
   /// Defaults to 0.
   final int minCharsForSuggestions;
+  
+  /// If set to true and if the user scrolls through the suggestion list, hide the keyboard automatically.
+  /// If set to false, the keyboard remains visible.
+  /// Throws an exception, if hideKeyboardOnDrag and hideSuggestionsOnKeyboardHide are both set to true as
+  /// they are mutual exclusive.
+  /// 
+  /// Defaults to false
+  final bool hideKeyboardOnDrag;
 
   /// Creates a [CupertinoTypeAheadField]
   CupertinoTypeAheadField(
@@ -507,11 +517,14 @@ class CupertinoTypeAheadField<T> extends StatefulWidget {
       this.keepSuggestionsOnLoading: true,
       this.keepSuggestionsOnSuggestionSelected: false,
       this.autoFlipDirection: false,
-      this.minCharsForSuggestions: 0})
+      this.minCharsForSuggestions: 0,
+      this.hideKeyboardOnDrag})
       : assert(animationStart >= 0.0 && animationStart <= 1.0),
         assert(
             direction == AxisDirection.down || direction == AxisDirection.up),
         assert(minCharsForSuggestions >= 0),
+        assert(
+          !hideKeyboardOnDrag || hideKeyboardOnDrag && !hideSuggestionsOnKeyboardHide),
         super(key: key);
 
   @override
@@ -673,6 +686,7 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
         hideOnError: widget.hideOnError,
         keepSuggestionsOnLoading: widget.keepSuggestionsOnLoading,
         minCharsForSuggestions: widget.minCharsForSuggestions,
+        hideKeyboardOnDrag: widget.hideKeyboardOnDrag,
       );
 
       double w = _suggestionsBox!.textBoxWidth;
@@ -783,6 +797,7 @@ class _SuggestionsList<T> extends StatefulWidget {
   final bool? hideOnError;
   final bool? keepSuggestionsOnLoading;
   final int? minCharsForSuggestions;
+  final bool hideKeyboardOnDrag;
 
   _SuggestionsList({
     required this.suggestionsBox,
@@ -805,6 +820,7 @@ class _SuggestionsList<T> extends StatefulWidget {
     this.hideOnError,
     this.keepSuggestionsOnLoading,
     this.minCharsForSuggestions,
+    this.hideKeyboardOnDrag: false,
   });
 
   @override
@@ -1103,6 +1119,9 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         padding: EdgeInsets.zero,
         primary: false,
         shrinkWrap: true,
+        keyboardDismissBehavior: widget.hideKeyboardOnDrag
+            ? ScrollViewKeyboardDismissBehavior.onDrag
+            : ScrollViewKeyboardDismissBehavior.manual,
         reverse: widget.suggestionsBox!.direction == AxisDirection.down
             ? false
             : true, // reverses the list to start at the bottom

--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -284,7 +284,8 @@ class TypeAheadFormField<T> extends FormField<String> {
       bool keepSuggestionsOnSuggestionSelected: false,
       bool autoFlipDirection: false,
       bool hideKeyboard: false,
-      int minCharsForSuggestions: 0})
+      int minCharsForSuggestions: 0,
+      bool hideKeyboardOnDrag: false})
       : assert(
             initialValue == null || textFieldConfiguration.controller == null),
         assert(minCharsForSuggestions >= 0),
@@ -336,6 +337,7 @@ class TypeAheadFormField<T> extends FormField<String> {
                 autoFlipDirection: autoFlipDirection,
                 hideKeyboard: hideKeyboard,
                 minCharsForSuggestions: minCharsForSuggestions,
+                hideKeyboardOnDrag: hideKeyboardOnDrag,
               );
             });
 
@@ -675,6 +677,14 @@ class TypeAheadField<T> extends StatefulWidget {
   ///
   /// Defaults to 0.
   final int minCharsForSuggestions;
+  
+  /// If set to true and if the user scrolls through the suggestion list, hide the keyboard automatically.
+  /// If set to false, the keyboard remains visible.
+  /// Throws an exception, if hideKeyboardOnDrag and hideSuggestionsOnKeyboardHide are both set to true as
+  /// they are mutual exclusive.
+  /// 
+  /// Defaults to false
+  final bool hideKeyboardOnDrag;
 
   /// Creates a [TypeAheadField]
   TypeAheadField(
@@ -704,11 +714,14 @@ class TypeAheadField<T> extends StatefulWidget {
       this.keepSuggestionsOnSuggestionSelected: false,
       this.autoFlipDirection: false,
       this.hideKeyboard: false,
-      this.minCharsForSuggestions: 0})
+      this.minCharsForSuggestions: 0,
+      this.hideKeyboardOnDrag: false})
       : assert(animationStart >= 0.0 && animationStart <= 1.0),
         assert(
             direction == AxisDirection.down || direction == AxisDirection.up),
         assert(minCharsForSuggestions >= 0),
+        assert(
+          !hideKeyboardOnDrag || hideKeyboardOnDrag && !hideSuggestionsOnKeyboardHide),
         super(key: key);
 
   @override
@@ -872,6 +885,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
         hideOnError: widget.hideOnError,
         keepSuggestionsOnLoading: widget.keepSuggestionsOnLoading,
         minCharsForSuggestions: widget.minCharsForSuggestions,
+        hideKeyboardOnDrag: widget.hideKeyboardOnDrag,
       );
 
       double w = _suggestionsBox!.textBoxWidth;
@@ -979,6 +993,7 @@ class _SuggestionsList<T> extends StatefulWidget {
   final bool? hideOnError;
   final bool? keepSuggestionsOnLoading;
   final int? minCharsForSuggestions;
+  final bool hideKeyboardOnDrag;
 
   _SuggestionsList({
     required this.suggestionsBox,
@@ -1002,6 +1017,7 @@ class _SuggestionsList<T> extends StatefulWidget {
     this.hideOnError,
     this.keepSuggestionsOnLoading,
     this.minCharsForSuggestions,
+    this.hideKeyboardOnDrag: false,
   });
 
   @override
@@ -1269,6 +1285,9 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       padding: EdgeInsets.zero,
       primary: false,
       shrinkWrap: true,
+      keyboardDismissBehavior: widget.hideKeyboardOnDrag
+          ? ScrollViewKeyboardDismissBehavior.onDrag
+          : ScrollViewKeyboardDismissBehavior.manual,
       controller: _scrollController,
       reverse: widget.suggestionsBox!.direction == AxisDirection.down
           ? false


### PR DESCRIPTION
This commit adds the option to the TypeAheadField to hide the keyboard as soon as the user drags the suggestion list. This is particular useful for devices with small screens and large entries in the suggestion box.