### PR TITLE
Fix/web release key selection

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -94,7 +94,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.4"
+    version: "4.1.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -106,28 +106,35 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -146,7 +153,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -181,21 +188,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.20.0"

--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -231,6 +231,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_keyboard_visibility/flutter_keyboard_visibility.dart';
 import 'package:flutter_typeahead/src/keyboard_suggestion_selection_notifier.dart';
+import 'package:flutter_typeahead/src/should_refresh_suggestion_focus_index_notifier.dart';
 
 import 'typedef.dart';
 import 'utils.dart';
@@ -763,7 +764,11 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   final Stream<bool>? _keyboardVisibility =
       (supportedPlatform) ? KeyboardVisibilityController().onChange : null;
   late StreamSubscription<bool>? _keyboardVisibilitySubscription;
+
   bool _areSuggestionsFocused = false;
+  late final _shouldRefreshSuggestionsFocusIndex =
+      ShouldRefreshSuggestionFocusIndexNotifier(
+          textFieldFocusNode: _effectiveFocusNode);
 
   @override
   void didChangeMetrics() {
@@ -931,6 +936,8 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
           minCharsForSuggestions: widget.minCharsForSuggestions,
           keyboardSuggestionSelectionNotifier:
               _keyboardSuggestionSelectionNotifier,
+          shouldRefreshSuggestionFocusIndexNotifier:
+              _shouldRefreshSuggestionsFocusIndex,
           giveTextFieldFocus: giveTextFieldFocus,
           onSuggestionFocus: onSuggestionFocus,
           onKeyEvent: _onKeyEvent,
@@ -1063,6 +1070,8 @@ class _SuggestionsList<T> extends StatefulWidget {
   final bool? keepSuggestionsOnLoading;
   final int? minCharsForSuggestions;
   final KeyboardSuggestionSelectionNotifier keyboardSuggestionSelectionNotifier;
+  final ShouldRefreshSuggestionFocusIndexNotifier
+      shouldRefreshSuggestionFocusIndexNotifier;
   final VoidCallback giveTextFieldFocus;
   final VoidCallback onSuggestionFocus;
   final KeyEventResult Function(FocusNode _, RawKeyEvent event) onKeyEvent;
@@ -1091,6 +1100,7 @@ class _SuggestionsList<T> extends StatefulWidget {
     this.keepSuggestionsOnLoading,
     this.minCharsForSuggestions,
     required this.keyboardSuggestionSelectionNotifier,
+    required this.shouldRefreshSuggestionFocusIndexNotifier,
     required this.giveTextFieldFocus,
     required this.onSuggestionFocus,
     required this.onKeyEvent,
@@ -1203,6 +1213,12 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
         widget.onSuggestionFocus();
       } else {
         widget.giveTextFieldFocus();
+      }
+    });
+
+    widget.shouldRefreshSuggestionFocusIndexNotifier.addListener(() {
+      if (_suggestionIndex != -1) {
+        _suggestionIndex = -1;
       }
     });
   }

--- a/lib/src/keyboard_suggestion_selection_notifier.dart
+++ b/lib/src/keyboard_suggestion_selection_notifier.dart
@@ -7,11 +7,10 @@ class KeyboardSuggestionSelectionNotifier
 
   void onKeyboardEvent(RawKeyEvent event) {
     // * we only handle key down event
-    if (event.runtimeType.toString() == 'RawKeyUpEvent') return;
+    if (event.runtimeType == RawKeyUpEvent) return;
 
     if (event.logicalKey == LogicalKeyboardKey.arrowDown ||
         event.logicalKey == LogicalKeyboardKey.arrowUp) {
-      print(event.logicalKey.debugName);
       if (value == event.logicalKey) {
         notifyListeners();
       } else {

--- a/lib/src/should_refresh_suggestion_focus_index_notifier.dart
+++ b/lib/src/should_refresh_suggestion_focus_index_notifier.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ShouldRefreshSuggestionFocusIndexNotifier extends ValueNotifier<void> {
+  ShouldRefreshSuggestionFocusIndexNotifier(
+      {required FocusNode? textFieldFocusNode})
+      : super(null) {
+    textFieldFocusNode?.addListener(() {
+      if (textFieldFocusNode.hasFocus) {
+        notifyListeners();
+      }
+    });
+  }
+}


### PR DESCRIPTION
This fix:
- [web] Weird behavior on release mode #426 
- [web] reset FocusNode suggestion when focus of TextField with Mouse

This doesn't fix:
- When a suggestion item is focused (desktop/web only), a click outside the suggestionList doesn't make the suggestion item unfocus.

The suggestionList is render in an overlay entry, therefore the widget tree doesn't represent what we want on the focus tree. More on this topic [here](https://github.com/flutter/flutter/issues/106923)

We might be able to fix this, but we must create a specific Focus widget that set a specific parent to the suggestion item focus node. So we must manipulate the focus tree directly, which is very tricky. I don't think that it is worth it

There are some weird behaviors on macos and windows platform. I'm pretty sure that they are related to the "focus in an OverlayEntry" problem. I think that creating issues for it could be a good idea