### PR TITLE
adding `autoFlipListDirection` option

### DIFF
--- a/lib/src/cupertino_flutter_typeahead.dart
+++ b/lib/src/cupertino_flutter_typeahead.dart
@@ -98,6 +98,7 @@ class CupertinoTypeAheadFormField<T> extends FormField<String> {
       bool keepSuggestionsOnLoading: true,
       bool keepSuggestionsOnSuggestionSelected: false,
       bool autoFlipDirection: false,
+      bool autoFlipListDirection: true,
       int minCharsForSuggestions: 0,
       bool hideKeyboardOnDrag: false})
       : assert(
@@ -147,6 +148,7 @@ class CupertinoTypeAheadFormField<T> extends FormField<String> {
                 keepSuggestionsOnSuggestionSelected:
                     keepSuggestionsOnSuggestionSelected,
                 autoFlipDirection: autoFlipDirection,
+                autoFlipListDirection: autoFlipListDirection,
                 minCharsForSuggestions: minCharsForSuggestions,
                 hideKeyboardOnDrag: hideKeyboardOnDrag,
               );
@@ -477,6 +479,12 @@ class CupertinoTypeAheadField<T> extends StatefulWidget {
   /// Defaults to false
   final bool autoFlipDirection;
 
+  /// If set to false, suggestion list will not be reversed according to the
+  /// [autoFlipDirection] property.
+  ///
+  /// Defaults to true.
+  final bool autoFlipListDirection;
+
   /// The minimum number of characters which must be entered before
   /// [suggestionsCallback] is triggered.
   ///
@@ -517,6 +525,7 @@ class CupertinoTypeAheadField<T> extends StatefulWidget {
     this.keepSuggestionsOnLoading: true,
     this.keepSuggestionsOnSuggestionSelected: false,
     this.autoFlipDirection: false,
+    this.autoFlipListDirection: true,
     this.minCharsForSuggestions: 0,
     this.hideKeyboardOnDrag: true,
   })  : assert(animationStart >= 0.0 && animationStart <= 1.0),
@@ -592,7 +601,12 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
     }
 
     this._suggestionsBox = _CupertinoSuggestionsBox(
-        context, widget.direction, widget.autoFlipDirection);
+      context,
+      widget.direction,
+      widget.autoFlipDirection,
+      widget.autoFlipListDirection,
+    );
+
     widget.suggestionsBoxController?._suggestionsBox = this._suggestionsBox;
     widget.suggestionsBoxController?._effectiveFocusNode =
         this._effectiveFocusNode;
@@ -1125,7 +1139,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
             : ScrollViewKeyboardDismissBehavior.manual,
         reverse: widget.suggestionsBox!.direction == AxisDirection.down
             ? false
-            : true, // reverses the list to start at the bottom
+            : widget.suggestionsBox!.autoFlipListDirection,
         children: this._suggestions!.map((T suggestion) {
           return GestureDetector(
             behavior: HitTestBehavior.translucent,
@@ -1336,6 +1350,7 @@ class _CupertinoSuggestionsBox {
   final BuildContext context;
   final AxisDirection desiredDirection;
   final bool autoFlipDirection;
+  final bool autoFlipListDirection;
 
   OverlayEntry? _overlayEntry;
   AxisDirection direction;
@@ -1347,8 +1362,12 @@ class _CupertinoSuggestionsBox {
   double textBoxHeight = 100.0;
   late double directionUpOffset;
 
-  _CupertinoSuggestionsBox(this.context, this.direction, this.autoFlipDirection)
-      : desiredDirection = direction;
+  _CupertinoSuggestionsBox(
+    this.context,
+    this.direction,
+    this.autoFlipDirection,
+    this.autoFlipListDirection,
+  ) : desiredDirection = direction;
 
   void open() {
     if (this.isOpened) return;

--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -286,6 +286,7 @@ class TypeAheadFormField<T> extends FormField<String> {
       bool keepSuggestionsOnLoading: true,
       bool keepSuggestionsOnSuggestionSelected: false,
       bool autoFlipDirection: false,
+      bool autoFlipListDirection: true,
       bool hideKeyboard: false,
       int minCharsForSuggestions: 0,
       bool hideKeyboardOnDrag: false})
@@ -339,6 +340,7 @@ class TypeAheadFormField<T> extends FormField<String> {
                 keepSuggestionsOnSuggestionSelected:
                     keepSuggestionsOnSuggestionSelected,
                 autoFlipDirection: autoFlipDirection,
+                autoFlipListDirection: autoFlipListDirection,
                 hideKeyboard: hideKeyboard,
                 minCharsForSuggestions: minCharsForSuggestions,
                 hideKeyboardOnDrag: hideKeyboardOnDrag,
@@ -674,6 +676,13 @@ class TypeAheadField<T> extends StatefulWidget {
   ///
   /// Defaults to false
   final bool autoFlipDirection;
+
+  /// If set to false, suggestion list will not be reversed according to the
+  /// [autoFlipDirection] property.
+  ///
+  /// Defaults to true.
+  final bool autoFlipListDirection;
+
   final bool hideKeyboard;
 
   /// The minimum number of characters which must be entered before
@@ -720,6 +729,7 @@ class TypeAheadField<T> extends StatefulWidget {
     this.keepSuggestionsOnLoading: true,
     this.keepSuggestionsOnSuggestionSelected: false,
     this.autoFlipDirection: false,
+    this.autoFlipListDirection: true,
     this.hideKeyboard: false,
     this.minCharsForSuggestions: 0,
     this.onSuggestionsBoxToggle,
@@ -823,8 +833,13 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       });
     }
 
-    this._suggestionsBox =
-        _SuggestionsBox(context, widget.direction, widget.autoFlipDirection);
+    this._suggestionsBox = _SuggestionsBox(
+      context,
+      widget.direction,
+      widget.autoFlipDirection,
+      widget.autoFlipListDirection,
+    );
+
     widget.suggestionsBoxController?._suggestionsBox = this._suggestionsBox;
     widget.suggestionsBoxController?._effectiveFocusNode =
         this._effectiveFocusNode;
@@ -1416,7 +1431,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
       controller: _scrollController,
       reverse: widget.suggestionsBox!.direction == AxisDirection.down
           ? false
-          : true, // reverses the list to start at the bottom
+          : widget.suggestionsBox!.autoFlipListDirection,
       children: List.generate(this._suggestions!.length, (index) {
         final suggestion = _suggestions!.elementAt(index);
         final focusNode = _focusNodes[index];
@@ -1782,6 +1797,7 @@ class _SuggestionsBox {
   final BuildContext context;
   final AxisDirection desiredDirection;
   final bool autoFlipDirection;
+  final bool autoFlipListDirection;
 
   OverlayEntry? _overlayEntry;
   AxisDirection direction;
@@ -1793,8 +1809,12 @@ class _SuggestionsBox {
   double textBoxHeight = 100.0;
   late double directionUpOffset;
 
-  _SuggestionsBox(this.context, this.direction, this.autoFlipDirection)
-      : desiredDirection = direction;
+  _SuggestionsBox(
+    this.context,
+    this.direction,
+    this.autoFlipDirection,
+    this.autoFlipListDirection,
+  ) : desiredDirection = direction;
 
   void open() {
     if (this.isOpened) return;


### PR DESCRIPTION
This PR adds the option to the `TypeAheadField` and `CupertinoTypeAheadFormField` to prevent auto reverse ability of the suggestion list even if `autoFlipDirection` is enabled. This is useful if the user or developer wants to see the list the same all the time.