### PR TITLE
Fix for flutter tests after pr #432

### DIFF
--- a/lib/src/cupertino_flutter_typeahead.dart
+++ b/lib/src/cupertino_flutter_typeahead.dart
@@ -762,6 +762,7 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
         onChanged: widget.textFieldConfiguration.onChanged,
         onEditingComplete: widget.textFieldConfiguration.onEditingComplete,
         onTap: widget.textFieldConfiguration.onTap,
+        onTapOutside: (_){},
         onSubmitted: widget.textFieldConfiguration.onSubmitted,
         inputFormatters: widget.textFieldConfiguration.inputFormatters,
         enabled: widget.textFieldConfiguration.enabled,


### PR DESCRIPTION
As stated in pr #432, that pull request broke flutter tests.

I believe this pr fixes that. I believe the problem was I forgot to apply the fix of #432 to the CupertinoFlutterTypeahed as well.

After this change and running ```flutter test test/flutter_typeahead_test.dart``` in my forked repo I get
```00:05 +7: All tests passed!```