### PR TITLE
Update flutter_typeahead.dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,16 @@ Manual control of the suggestions box can be achieved by creating an instance of
 passing it to the `suggestionsBoxController` property. This will allow you to manually open, close, toggle, or 
 resize the suggestions box.
 
+`SuggestionsBoxController` also has the methods `openUnfocused`, `closeUnfocused`, and `toggleUnfocused`, which allow you to open/close the suggestions box without needing to focus/unfocus the text field. This makes it possible to use the `TypeAheadField` as a drop-down list by disabling the text field and toggling the suggestion box manually via a gesture detector. For example: 
+```dart
+GestureDetector(
+        onTap: _suggestionsBoxController.toggleUnfocused,
+        child: TypeAheadFormField(
+                suggestionsBoxController: _suggestionsBoxController,
+                textFieldConfiguration: TextFieldConfiguration(
+                        enabled: false)))
+```
+
 ## For more information
 Visit the [API Documentation](https://pub.dartlang.org/documentation/flutter_typeahead/latest/)
 

--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -2028,6 +2028,11 @@ class SuggestionsBoxController {
     _effectiveFocusNode?.requestFocus();
   }
 
+  /// Opens the suggestions box without focusing the text field
+  void openUnfocused() {
+    _suggestionsBox?.open();
+  }
+
   bool isOpened() {
     return _suggestionsBox?.isOpened ?? false;
   }
@@ -2037,12 +2042,26 @@ class SuggestionsBoxController {
     _effectiveFocusNode?.unfocus();
   }
 
+  /// Closes the suggestions box without un-focusing the text field
+  void closeUnfocused() {
+    _suggestionsBox?.close();
+  }
+
   /// Opens the suggestions box if closed and vice-versa
   void toggle() {
     if (_suggestionsBox?.isOpened ?? false) {
       close();
     } else {
       open();
+    }
+  }
+
+  /// Opens the suggestions box if closed and vice-versa without focusing/un-focusing the text field
+  void toggleUnfocused() {
+    if (_suggestionsBox?.isOpened ?? false) {
+      closeUnfocused();
+    } else {
+      openUnfocused();
     }
   }
 

--- a/test/suggestionsbox_controller_test.dart
+++ b/test/suggestionsbox_controller_test.dart
@@ -1,0 +1,141 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+
+class TestPage extends StatefulWidget {
+  final SuggestionsBoxController suggestionsBoxController;
+  TestPage({Key? key, required this.suggestionsBoxController})
+      : super(key: key);
+
+  @override
+  State<StatefulWidget> createState() => TestPageState();
+}
+
+class TestPageState extends State<TestPage> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _controller = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.text = 'Default text';
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: Text('Test'),
+        ),
+        body: Form(
+          key: _formKey,
+          child: TypeAheadFormField<String>(
+            suggestionsBoxController: widget.suggestionsBoxController,
+            textFieldConfiguration: TextFieldConfiguration(
+              controller: _controller,
+            ),
+            suggestionsCallback: (pattern) {
+              return ['aaa'];
+            },
+            itemBuilder: (context, String suggestion) {
+              return ListTile(
+                title: Text(suggestion),
+              );
+            },
+            onSuggestionSelected: (String suggestion) =>
+                this._controller.text = suggestion,
+          ),
+        ));
+  }
+}
+
+void main() {
+  group('SuggestionsBoxController', () {
+    testWidgets('open, close, toggle', (WidgetTester tester) async {
+      final _suggestionsBoxController = SuggestionsBoxController();
+
+      await tester.pumpWidget(MaterialApp(
+          home: TestPage(suggestionsBoxController: _suggestionsBoxController)));
+      await tester.pumpAndSettle();
+
+      final textFieldFinder = find.byKey(TestKeys.textFieldKey);
+      final TextField textField = tester.firstWidget(textFieldFinder);
+      expect(textField.focusNode?.hasFocus, false);
+
+      _suggestionsBoxController.open();
+      await tester.pumpAndSettle(Duration(milliseconds: 100));
+      expect(textField.focusNode?.hasFocus, true);
+      expect(_suggestionsBoxController.isOpened(), true);
+      var firstSuggestionText = find.text("aaa");
+      expect(firstSuggestionText, findsOneWidget);
+
+      _suggestionsBoxController.close();
+      await tester.pumpAndSettle(Duration(milliseconds: 100));
+      expect(textField.focusNode?.hasFocus, false);
+      expect(_suggestionsBoxController.isOpened(), false);
+      firstSuggestionText = find.text("aaa");
+      expect(firstSuggestionText, findsNothing);
+
+      _suggestionsBoxController.toggle();
+      await tester.pumpAndSettle(Duration(milliseconds: 100));
+      expect(textField.focusNode?.hasFocus, true);
+      expect(_suggestionsBoxController.isOpened(), true);
+      firstSuggestionText = find.text("aaa");
+      expect(firstSuggestionText, findsOneWidget);
+
+      _suggestionsBoxController.toggle();
+      await tester.pumpAndSettle(Duration(milliseconds: 100));
+      expect(textField.focusNode?.hasFocus, false);
+      expect(_suggestionsBoxController.isOpened(), false);
+      firstSuggestionText = find.text("aaa");
+      expect(firstSuggestionText, findsNothing);
+    });
+
+    testWidgets('openUnfocused, closeUnfocused, toggleUnfocused',
+        (WidgetTester tester) async {
+      final _suggestionsBoxController = SuggestionsBoxController();
+
+      await tester.pumpWidget(MaterialApp(
+          home: TestPage(suggestionsBoxController: _suggestionsBoxController)));
+      await tester.pumpAndSettle();
+
+      final textFieldFinder = find.byKey(TestKeys.textFieldKey);
+      final TextField textField = tester.firstWidget(textFieldFinder);
+      expect(textField.focusNode?.hasFocus, false);
+
+      _suggestionsBoxController.openUnfocused();
+      await tester.pumpAndSettle(Duration(milliseconds: 100));
+      expect(textField.focusNode?.hasFocus, false);
+      expect(_suggestionsBoxController.isOpened(), true);
+      var firstSuggestionText = find.text("aaa");
+      expect(firstSuggestionText, findsOneWidget);
+
+      _suggestionsBoxController.closeUnfocused();
+      await tester.pumpAndSettle(Duration(milliseconds: 100));
+      expect(textField.focusNode?.hasFocus, false);
+      expect(_suggestionsBoxController.isOpened(), false);
+      firstSuggestionText = find.text("aaa");
+      expect(firstSuggestionText, findsNothing);
+
+      _suggestionsBoxController.toggleUnfocused();
+      await tester.pumpAndSettle(Duration(milliseconds: 100));
+      expect(textField.focusNode?.hasFocus, false);
+      expect(_suggestionsBoxController.isOpened(), true);
+      firstSuggestionText = find.text("aaa");
+      expect(firstSuggestionText, findsOneWidget);
+
+      _suggestionsBoxController.toggleUnfocused();
+      await tester.pumpAndSettle(Duration(milliseconds: 100));
+      expect(textField.focusNode?.hasFocus, false);
+      expect(_suggestionsBoxController.isOpened(), false);
+      firstSuggestionText = find.text("aaa");
+      expect(firstSuggestionText, findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
Added ability to toggle the suggestion box without needing to focus/unfocus the text field. This is useful in case one wants to disable the text field e.g. in order to make it work like a drop down. 

The drop down implementation would look like this:
GestureDetector(
        onTap: () {_suggestionsBoxController.toggleUnfocused();},
        child: TypeAheadFormField<DropDownItem>(
                 textFieldConfiguration: TextFieldConfiguration(
                        enabled: false)))