### PR TITLE
fix: Use maybeOf for scrollable to not throw an exception in flutter …

### DIFF
--- a/lib/src/cupertino_flutter_typeahead.dart
+++ b/lib/src/cupertino_flutter_typeahead.dart
@@ -646,7 +646,7 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    ScrollableState? scrollableState = Scrollable.of(context);
+    final scrollableState = Scrollable.maybeOf(context);
     if (scrollableState != null) {
       // The TypeAheadField is inside a scrollable widget
       _scrollPosition = scrollableState.position;

--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -895,7 +895,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    ScrollableState? scrollableState = Scrollable.of(context);
+    final scrollableState = Scrollable.maybeOf(context);
     if (scrollableState != null) {
       // The TypeAheadField is inside a scrollable widget
       _scrollPosition = scrollableState.position;


### PR DESCRIPTION
fix: Use maybeOf for scrollable to not throw an exception in flutter 3.7.0