### PR TITLE
fix: remove top padding on scrollbar

### DIFF
--- a/lib/src/flutter_typeahead.dart
+++ b/lib/src/flutter_typeahead.dart
@@ -1467,9 +1467,13 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
     );
 
     if (widget.decoration!.hasScrollbar) {
-      child = Scrollbar(
-        controller: _scrollController,
-        child: child,
+      child = MediaQuery.removePadding(
+        context: context,
+        removeTop: true,
+        child: Scrollbar(
+          controller: _scrollController,
+          child: child,
+        ),
       );
     }
 


### PR DESCRIPTION
Scrollbar has implicit top padding sometimes.

![image](https://user-images.githubusercontent.com/56959368/216938663-81e3461b-ffc7-4f93-b22c-65ca3da2bc25.png)


Solution:
Wrapping the Scrollbar widget with MediaQuery.removePadding and setting removeTop: true will solve this issue.

Related:
https://stackoverflow.com/questions/64404873/remove-the-top-padding-from-scrollbar-when-wrapping-listview
