### PR TITLE
Fix for incorrect vertical offset calculation of suggestion box for flutter mobile web

### DIFF
--- a/lib/src/cupertino/field/cupertino_typeahead_field.dart
+++ b/lib/src/cupertino/field/cupertino_typeahead_field.dart
@@ -502,7 +502,7 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
               widget.suggestionsBoxDecoration.offsetX,
               _suggestionsBox!.direction == AxisDirection.down
                   ? _suggestionsBox!.textBoxHeight + widget.suggestionsBoxVerticalOffset
-                  : _suggestionsBox!.directionUpOffset),
+                  : -1 * widget.suggestionsBoxVerticalOffset),
           child: _suggestionsBox!.direction == AxisDirection.down
               ? suggestionsList
               : FractionalTranslation(

--- a/lib/src/cupertino/field/cupertino_typeahead_field.dart
+++ b/lib/src/cupertino/field/cupertino_typeahead_field.dart
@@ -502,7 +502,7 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
               widget.suggestionsBoxDecoration.offsetX,
               _suggestionsBox!.direction == AxisDirection.down
                   ? _suggestionsBox!.textBoxHeight + widget.suggestionsBoxVerticalOffset
-                  : -1 * widget.suggestionsBoxVerticalOffset),
+                  : -widget.suggestionsBoxVerticalOffset),
           child: _suggestionsBox!.direction == AxisDirection.down
               ? suggestionsList
               : FractionalTranslation(

--- a/lib/src/material/field/typeahead_field.dart
+++ b/lib/src/material/field/typeahead_field.dart
@@ -807,7 +807,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
             _suggestionsBox!.direction == AxisDirection.down
                 ? _suggestionsBox!.textBoxHeight +
                 widget.suggestionsBoxVerticalOffset
-                : _suggestionsBox!.directionUpOffset),
+                : -1 * widget.suggestionsBoxVerticalOffset),
         child: _suggestionsBox!.direction == AxisDirection.down
             ? suggestionsList
             : FractionalTranslation(

--- a/lib/src/material/field/typeahead_field.dart
+++ b/lib/src/material/field/typeahead_field.dart
@@ -807,7 +807,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
             _suggestionsBox!.direction == AxisDirection.down
                 ? _suggestionsBox!.textBoxHeight +
                 widget.suggestionsBoxVerticalOffset
-                : -1 * widget.suggestionsBoxVerticalOffset),
+                : -widget.suggestionsBoxVerticalOffset),
         child: _suggestionsBox!.direction == AxisDirection.down
             ? suggestionsList
             : FractionalTranslation(

--- a/test/cupertino_typeahead_test.dart
+++ b/test/cupertino_typeahead_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'helpers/cupertino_typeahead_helper.dart';
 
+/// Cupertino Typeahead widget tests where there are 6 typeaheads. To test overlays and other widgets.
 void main() {
   group("Cupertino TypeAhead widget tests", () {
     testWidgets("Initial UI Test", (WidgetTester tester) async {
@@ -74,7 +75,7 @@ void main() {
       expect(typeAheadSuggestionBoxTester.offset, Offset(0.0, 34.0));
     });
 
-    testWidgets("Search with last type ahead and check the offset of the first suggestion box", (WidgetTester tester) async {
+    testWidgets("Search with last type ahead and check the offset of the last suggestion box", (WidgetTester tester) async {
       await tester.pumpWidget(CupertinoTypeAheadHelper.getCupertinoTypeAheadPage());
       await tester.pumpAndSettle();
 

--- a/test/cupertino_typeahead_test.dart
+++ b/test/cupertino_typeahead_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'helpers/cupertino_typeahead_helper.dart';
+
+void main() {
+  group("Cupertino TypeAhead widget tests", () {
+    testWidgets("Initial UI Test", (WidgetTester tester) async {
+      await tester.pumpWidget(CupertinoTypeAheadHelper.getCupertinoTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      expect(find.text("Cupertino TypeAhead test"), findsOneWidget);
+      expect(find.byType(CupertinoTypeAheadFormField<String>), findsNWidgets(6));
+      expect(find.byType(CompositedTransformFollower), findsNothing);
+    });
+
+    testWidgets("No results found test", (WidgetTester tester) async {
+      await tester.pumpWidget(CupertinoTypeAheadHelper.getCupertinoTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(CupertinoTypeAheadFormField<String>).first;
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "Chocolates");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.byType(CompositedTransformFollower), findsNWidgets(2));
+
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.text("No results found!"), findsOneWidget);
+    });
+
+    testWidgets("Search one item", (WidgetTester tester) async {
+      await tester.pumpWidget(CupertinoTypeAheadHelper.getCupertinoTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(CupertinoTypeAheadFormField<String>).first;
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "Cheese");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.byType(CompositedTransformFollower), findsNWidgets(2));
+
+      await tester.tap(find.text("Cheese").last);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.text("Cheese"), findsOneWidget);
+    });
+
+    testWidgets("Search two items", (WidgetTester tester) async {
+      await tester.pumpWidget(CupertinoTypeAheadHelper.getCupertinoTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(CupertinoTypeAheadFormField<String>).first;
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "B");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      expect(find.text("Bread"), findsOneWidget);
+      expect(find.text("Burger"), findsOneWidget);
+    });
+
+    testWidgets("Search with first type ahead and check the offset of the first suggestion box", (WidgetTester tester) async {
+      await tester.pumpWidget(CupertinoTypeAheadHelper.getCupertinoTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(CupertinoTypeAheadFormField<String>).first;
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "Bread");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      final typeAheadSuggestionBox = find.byType(CompositedTransformFollower).last;
+      final CompositedTransformFollower typeAheadSuggestionBoxTester = tester.widget<CompositedTransformFollower>(typeAheadSuggestionBox);
+      expect(typeAheadSuggestionBoxTester.offset, Offset(0.0, 34.0));
+    });
+
+    testWidgets("Search with last type ahead and check the offset of the first suggestion box", (WidgetTester tester) async {
+      await tester.pumpWidget(CupertinoTypeAheadHelper.getCupertinoTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(CupertinoTypeAheadFormField<String>).last;
+      final scrollView = find.descendant(of: find.byType(SingleChildScrollView), matching: find.byType(Scrollable));
+
+      await tester.dragUntilVisible(typeAheadField, scrollView, Offset(0, 1000));
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "Milk");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      final typeAheadSuggestionBox = find.byType(CompositedTransformFollower).last;
+      final CompositedTransformFollower typeAheadSuggestionBoxTester = tester.widget<CompositedTransformFollower>(typeAheadSuggestionBox);
+      expect(typeAheadSuggestionBoxTester.offset, Offset(0.0, -5.0));
+    });
+  });
+}

--- a/test/helpers/cupertino_typeahead_helper.dart
+++ b/test/helpers/cupertino_typeahead_helper.dart
@@ -59,8 +59,9 @@ class _CupertinoTypeAheadPageState extends State<CupertinoTypeAheadPage> {
   }
 
   /// Widget that returns the CupertineTypeAheadFormField
-  Widget get _getTypeAhead {
-    _controllers.add(TextEditingController());
+  Widget _getTypeAhead() {
+    final controller = TextEditingController();
+    _controllers.add(controller);
 
     return CupertinoTypeAheadFormField<String>(
       textFieldConfiguration: CupertinoTextFieldConfiguration(

--- a/test/helpers/cupertino_typeahead_helper.dart
+++ b/test/helpers/cupertino_typeahead_helper.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 
+/// Helper class to get the cupertino typeahead test page
 class CupertinoTypeAheadHelper {
   static Widget getCupertinoTypeAheadPage() {
     return MaterialApp(
@@ -11,6 +12,7 @@ class CupertinoTypeAheadHelper {
   }
 }
 
+/// The widget that will be returned for the cupertino typeahead test page
 class CupertinoTypeAheadPage extends StatefulWidget {
   final String? title;
 
@@ -23,6 +25,7 @@ class CupertinoTypeAheadPage extends StatefulWidget {
 class _CupertinoTypeAheadPageState extends State<CupertinoTypeAheadPage> {
   final List<TextEditingController> _controllers = [];
 
+  /// Items that will be used to search
   final List<String> foodItems = [
     "Bread",
     "Burger",
@@ -32,7 +35,7 @@ class _CupertinoTypeAheadPageState extends State<CupertinoTypeAheadPage> {
     "Orange"
   ];
 
-  // This is to trigger a loading effect when searching for items
+  /// This is to trigger a loading builder when searching for items
   Future<List<String>> _getFoodItems(String pattern) async {
     pattern = pattern.trim();
     if (pattern.isNotEmpty) {
@@ -47,6 +50,7 @@ class _CupertinoTypeAheadPageState extends State<CupertinoTypeAheadPage> {
     }
   }
 
+  /// Widget that will be displayed when no results were found
   Widget _getNoResultText(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(10),
@@ -54,9 +58,9 @@ class _CupertinoTypeAheadPageState extends State<CupertinoTypeAheadPage> {
     );
   }
 
-  Widget _getTypeAhead() {
-    final controller = TextEditingController();
-    _controllers.add(controller);
+  /// Widget that returns the CupertineTypeAheadFormField
+  Widget get _getTypeAhead {
+    _controllers.add(TextEditingController());
 
     return CupertinoTypeAheadFormField<String>(
       textFieldConfiguration: CupertinoTextFieldConfiguration(

--- a/test/helpers/cupertino_typeahead_helper.dart
+++ b/test/helpers/cupertino_typeahead_helper.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+
+class CupertinoTypeAheadHelper {
+  static Widget getCupertinoTypeAheadPage() {
+    return MaterialApp(
+      home: CupertinoTypeAheadPage(),
+    );
+  }
+}
+
+class CupertinoTypeAheadPage extends StatefulWidget {
+  final String? title;
+
+  const CupertinoTypeAheadPage({Key? super.key, this.title});
+
+  @override
+  State<CupertinoTypeAheadPage> createState() => _CupertinoTypeAheadPageState();
+}
+
+class _CupertinoTypeAheadPageState extends State<CupertinoTypeAheadPage> {
+  final List<TextEditingController> _controllers = [];
+
+  final List<String> foodItems = [
+    "Bread",
+    "Burger",
+    "Cheese",
+    "Milk",
+    "Milkshake",
+    "Orange"
+  ];
+
+  // This is to trigger a loading effect when searching for items
+  Future<List<String>> _getFoodItems(String pattern) async {
+    pattern = pattern.trim();
+    if (pattern.isNotEmpty) {
+      return Future.delayed(
+          const Duration(seconds: 2),
+              () => foodItems
+              .where(
+                  (item) => item.toLowerCase().contains(pattern.toLowerCase()))
+              .toList());
+    } else {
+      return Future.delayed(const Duration(seconds: 2), () => []);
+    }
+  }
+
+  Widget _getNoResultText(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(10),
+      child: Text("No results found!"),
+    );
+  }
+
+  Widget _getTypeAhead() {
+    final controller = TextEditingController();
+    _controllers.add(controller);
+
+    return CupertinoTypeAheadFormField<String>(
+      textFieldConfiguration: CupertinoTextFieldConfiguration(
+        inputFormatters: [LengthLimitingTextInputFormatter(50)],
+        controller: controller,
+      ),
+      autoFlipDirection: true,
+      loadingBuilder: (context) {
+        return Container(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.grey,
+            ),
+            borderRadius: BorderRadius.circular(5),
+          ),
+          constraints: BoxConstraints(
+            minHeight: 50,
+            maxHeight: 150,
+          ),
+          child: Center(
+            child: CircularProgressIndicator(),
+          ),
+        );
+      },
+      suggestionsCallback: _getFoodItems,
+      noItemsFoundBuilder: _getNoResultText,
+      itemBuilder: (context, String suggestion) {
+        return CupertinoListTile(
+          backgroundColor: Colors.white,
+          title: Text(suggestion),
+        );
+      },
+      suggestionsBoxDecoration: CupertinoSuggestionsBoxDecoration(
+        hasScrollbar: true,
+      ),
+      getImmediateSuggestions: false,
+      onSuggestionSelected: (String suggestion) => controller.text = suggestion,
+      minCharsForSuggestions: 1,
+    );
+  }
+
+  @override
+  void dispose() {
+    for (TextEditingController controller in _controllers) controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(
+        title: Text('Cupertino TypeAhead test'),
+      ),
+      body: SingleChildScrollView(
+        child: Container(
+          margin: EdgeInsets.all(10),
+          child: ListView.separated(
+            shrinkWrap: true,
+            separatorBuilder: (context, index) => SizedBox(height: 100),
+            physics: const NeverScrollableScrollPhysics(),
+            itemBuilder: (context, index) => _getTypeAhead(),
+            itemCount: 6,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/helpers/material_typeahead_helper.dart
+++ b/test/helpers/material_typeahead_helper.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 
+/// Helper class to get the material typeahead test page
 class MaterialTypeAheadHelper {
   static Widget getMaterialTypeAheadPage() {
     return MaterialApp(
@@ -10,6 +11,7 @@ class MaterialTypeAheadHelper {
   }
 }
 
+/// The widget that will be returned for the material typeahead test page
 class MaterialTypeAheadPage extends StatefulWidget {
   final String? title;
 
@@ -22,6 +24,7 @@ class MaterialTypeAheadPage extends StatefulWidget {
 class _MaterialTypeAheadPageState extends State<MaterialTypeAheadPage> {
   final List<TextEditingController> _controllers = [];
 
+  /// Items that will be used to search
   final List<String> foodItems = [
     "Bread",
     "Burger",
@@ -31,7 +34,7 @@ class _MaterialTypeAheadPageState extends State<MaterialTypeAheadPage> {
     "Orange"
   ];
 
-  // This is to trigger a loading effect when searching for items
+  /// This is to trigger a loading builder when searching for items
   Future<List<String>> _getFoodItems(String pattern) async {
     pattern = pattern.trim();
     if (pattern.isNotEmpty) {
@@ -46,6 +49,7 @@ class _MaterialTypeAheadPageState extends State<MaterialTypeAheadPage> {
     }
   }
 
+  /// Widget that will be displayed when no results were found
   Widget _getNoResultText(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(10),
@@ -53,9 +57,9 @@ class _MaterialTypeAheadPageState extends State<MaterialTypeAheadPage> {
     );
   }
 
-  Widget _getTypeAhead() {
-    final controller = TextEditingController();
-    _controllers.add(controller);
+  /// Widget that returns the MaterialTypeAheadFormField
+  Widget get _getTypeAhead {
+    _controllers.add(TextEditingController());
 
     return TypeAheadFormField<String>(
       textFieldConfiguration: TextFieldConfiguration(

--- a/test/helpers/material_typeahead_helper.dart
+++ b/test/helpers/material_typeahead_helper.dart
@@ -58,8 +58,9 @@ class _MaterialTypeAheadPageState extends State<MaterialTypeAheadPage> {
   }
 
   /// Widget that returns the MaterialTypeAheadFormField
-  Widget get _getTypeAhead {
-    _controllers.add(TextEditingController());
+  Widget _getTypeAhead() {
+    final controller = TextEditingController();
+    _controllers.add(controller);
 
     return TypeAheadFormField<String>(
       textFieldConfiguration: TextFieldConfiguration(

--- a/test/helpers/material_typeahead_helper.dart
+++ b/test/helpers/material_typeahead_helper.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+
+class MaterialTypeAheadHelper {
+  static Widget getMaterialTypeAheadPage() {
+    return MaterialApp(
+      home: MaterialTypeAheadPage(),
+    );
+  }
+}
+
+class MaterialTypeAheadPage extends StatefulWidget {
+  final String? title;
+
+  const MaterialTypeAheadPage({Key? super.key, this.title});
+
+  @override
+  State<MaterialTypeAheadPage> createState() => _MaterialTypeAheadPageState();
+}
+
+class _MaterialTypeAheadPageState extends State<MaterialTypeAheadPage> {
+  final List<TextEditingController> _controllers = [];
+
+  final List<String> foodItems = [
+    "Bread",
+    "Burger",
+    "Cheese",
+    "Milk",
+    "Milkshake",
+    "Orange"
+  ];
+
+  // This is to trigger a loading effect when searching for items
+  Future<List<String>> _getFoodItems(String pattern) async {
+    pattern = pattern.trim();
+    if (pattern.isNotEmpty) {
+      return Future.delayed(
+          const Duration(seconds: 2),
+              () => foodItems
+              .where(
+                  (item) => item.toLowerCase().contains(pattern.toLowerCase()))
+              .toList());
+    } else {
+      return Future.delayed(const Duration(seconds: 2), () => []);
+    }
+  }
+
+  Widget _getNoResultText(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(10),
+      child: Text("No results found!"),
+    );
+  }
+
+  Widget _getTypeAhead() {
+    final controller = TextEditingController();
+    _controllers.add(controller);
+
+    return TypeAheadFormField<String>(
+      textFieldConfiguration: TextFieldConfiguration(
+        inputFormatters: [LengthLimitingTextInputFormatter(50)],
+        controller: controller,
+        decoration: InputDecoration(
+            labelText: "Please provide a search term",
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(5),
+            )),
+      ),
+      autoFlipDirection: true,
+      loadingBuilder: (context) {
+        return Container(
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.grey,
+            ),
+            borderRadius: BorderRadius.circular(5),
+          ),
+          constraints: BoxConstraints(
+            minHeight: 50,
+            maxHeight: 150,
+          ),
+          child: Center(
+            child: CircularProgressIndicator(),
+          ),
+        );
+      },
+      suggestionsCallback: _getFoodItems,
+      noItemsFoundBuilder: _getNoResultText,
+      itemBuilder: (context, String suggestion) {
+        return ListTile(
+          tileColor: Colors.white,
+          title: Text(suggestion),
+        );
+      },
+      suggestionsBoxDecoration: SuggestionsBoxDecoration(
+        elevation: 2,
+        hasScrollbar: true,
+      ),
+      getImmediateSuggestions: false,
+      onSuggestionSelected: (String suggestion) => controller.text = suggestion,
+      minCharsForSuggestions: 1,
+    );
+  }
+
+  @override
+  void dispose() {
+    for (TextEditingController controller in _controllers) controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: false,
+      appBar: AppBar(
+        title: Text('Material TypeAhead test'),
+      ),
+      body: SingleChildScrollView(
+        child: Container(
+          margin: EdgeInsets.all(10),
+          child: ListView.separated(
+            shrinkWrap: true,
+            separatorBuilder: (context, index) => SizedBox(height: 100),
+            physics: const NeverScrollableScrollPhysics(),
+            itemBuilder: (context, index) => _getTypeAhead(),
+            itemCount: 6,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/material_typeahead_test.dart
+++ b/test/material_typeahead_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 import 'helpers/material_typeahead_helper.dart';
 
+/// Material Typeahead widget tests where there are 6 typeaheads. To test overlays and other widgets.
 void main() {
   group("Material TypeAhead widget tests", () {
     testWidgets("Initial UI Test", (WidgetTester tester) async {
@@ -74,7 +75,7 @@ void main() {
       expect(typeAheadSuggestionBoxTester.offset, Offset(0.0, 61.0));
     });
 
-    testWidgets("Search with last type ahead and check the offset of the first suggestion box", (WidgetTester tester) async {
+    testWidgets("Search with last type ahead and check the offset of the last suggestion box", (WidgetTester tester) async {
       await tester.pumpWidget(MaterialTypeAheadHelper.getMaterialTypeAheadPage());
       await tester.pumpAndSettle();
 

--- a/test/material_typeahead_test.dart
+++ b/test/material_typeahead_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_typeahead/flutter_typeahead.dart';
+import 'helpers/material_typeahead_helper.dart';
+
+void main() {
+  group("Material TypeAhead widget tests", () {
+    testWidgets("Initial UI Test", (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialTypeAheadHelper.getMaterialTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      expect(find.text("Material TypeAhead test"), findsOneWidget);
+      expect(find.byType(TypeAheadFormField<String>), findsNWidgets(6));
+      expect(find.byType(CompositedTransformFollower), findsNothing);
+    });
+
+    testWidgets("No results found test", (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialTypeAheadHelper.getMaterialTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(TypeAheadFormField<String>).first;
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "Chocolates");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.byType(CompositedTransformFollower), findsNWidgets(2));
+
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.text("No results found!"), findsOneWidget);
+    });
+
+    testWidgets("Search one item", (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialTypeAheadHelper.getMaterialTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(TypeAheadFormField<String>).first;
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "Cheese");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.byType(CompositedTransformFollower), findsNWidgets(2));
+
+      await tester.tap(find.text("Cheese").last);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      expect(find.text("Cheese"), findsOneWidget);
+    });
+
+    testWidgets("Search two items", (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialTypeAheadHelper.getMaterialTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(TypeAheadFormField<String>).first;
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "B");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      expect(find.text("Bread"), findsOneWidget);
+      expect(find.text("Burger"), findsOneWidget);
+    });
+
+    testWidgets("Search with first type ahead and check the offset of the first suggestion box", (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialTypeAheadHelper.getMaterialTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(TypeAheadFormField<String>).first;
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "Bread");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      final typeAheadSuggestionBox = find.byType(CompositedTransformFollower).last;
+      final CompositedTransformFollower typeAheadSuggestionBoxTester = tester.widget<CompositedTransformFollower>(typeAheadSuggestionBox);
+      expect(typeAheadSuggestionBoxTester.offset, Offset(0.0, 61.0));
+    });
+
+    testWidgets("Search with last type ahead and check the offset of the first suggestion box", (WidgetTester tester) async {
+      await tester.pumpWidget(MaterialTypeAheadHelper.getMaterialTypeAheadPage());
+      await tester.pumpAndSettle();
+
+      final typeAheadField = find.byType(TypeAheadFormField<String>).last;
+      final scrollView = find.descendant(of: find.byType(SingleChildScrollView), matching: find.byType(Scrollable));
+
+      await tester.dragUntilVisible(typeAheadField, scrollView, Offset(0, 1000));
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.tap(typeAheadField);
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+      await tester.enterText(typeAheadField, "Milk");
+      await tester.pumpAndSettle(const Duration(seconds: 2));
+
+      final typeAheadSuggestionBox = find.byType(CompositedTransformFollower).last;
+      final CompositedTransformFollower typeAheadSuggestionBoxTester = tester.widget<CompositedTransformFollower>(typeAheadSuggestionBox);
+      expect(typeAheadSuggestionBoxTester.offset, Offset(0.0, -5.0));
+    });
+  });
+}


### PR DESCRIPTION
Hello

After testing out flutter web app on mobile web on release mode, we saw that the vertical offset of suggestion is not always calculated correctly for the input field. This is specifically the case when suggestion box direction should be up. In other words above the input field. This was also tested when the page is scrollable and the keyboard might be above the field and some cases below the field. 

**Please Note:** New tests were written in separate files for reusability and separation of concern. I have also expanded these tests as some of the test cases were missing.

Feel free to leave comments or any suggestions.

Thanks for your work.

Wilhelm R.

