### PR TITLE
support placeholder style customization

### DIFF
--- a/lib/src/cupertino/field/cupertino_text_field_configuration.dart
+++ b/lib/src/cupertino/field/cupertino_text_field_configuration.dart
@@ -36,6 +36,7 @@ class CupertinoTextFieldConfiguration {
   final BoxDecoration decoration;
   final EdgeInsetsGeometry padding;
   final String? placeholder;
+  final TextStyle? placeholderStyle;
   final Widget? prefix;
   final OverlayVisibilityMode prefixMode;
   final Widget? suffix;
@@ -74,6 +75,7 @@ class CupertinoTextFieldConfiguration {
     this.decoration = _kDefaultRoundedBorderDecoration,
     this.padding = const EdgeInsets.all(6.0),
     this.placeholder,
+    this.placeholderStyle,
     this.prefix,
     this.prefixMode = OverlayVisibilityMode.always,
     this.suffix,
@@ -113,6 +115,7 @@ class CupertinoTextFieldConfiguration {
     BoxDecoration? decoration,
     EdgeInsetsGeometry? padding,
     String? placeholder,
+    TextStyle? placeholderStyle,
     Widget? prefix,
     OverlayVisibilityMode? prefixMode,
     Widget? suffix,
@@ -150,6 +153,7 @@ class CupertinoTextFieldConfiguration {
       decoration: decoration ?? this.decoration,
       padding: padding ?? this.padding,
       placeholder: placeholder ?? this.placeholder,
+      placeholderStyle: placeholderStyle ?? this.placeholderStyle,
       prefix: prefix ?? this.prefix,
       prefixMode: prefixMode ?? this.prefixMode,
       suffix: suffix ?? this.suffix,

--- a/lib/src/cupertino/field/cupertino_typeahead_field.dart
+++ b/lib/src/cupertino/field/cupertino_typeahead_field.dart
@@ -524,6 +524,7 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
         decoration: widget.textFieldConfiguration.decoration,
         padding: widget.textFieldConfiguration.padding,
         placeholder: widget.textFieldConfiguration.placeholder,
+        placeholderStyle: widget.textFieldConfiguration.placeholderStyle,
         prefix: widget.textFieldConfiguration.prefix,
         prefixMode: widget.textFieldConfiguration.prefixMode,
         suffix: widget.textFieldConfiguration.suffix,


### PR DESCRIPTION
We can customize text style, but it's also interesting to set placeholder style accordingly, since underlying widget has support for it:

https://api.flutter.dev/flutter/cupertino/CupertinoTextField/placeholderStyle.html