### PR TITLE
Support alternative (for example Grid) layouts of results

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,41 @@
 [![Pub](https://img.shields.io/pub/v/flutter_typeahead)](https://pub.dev/packages/flutter_typeahead)
 
 # Flutter TypeAhead
+
 A TypeAhead (autocomplete) widget for Flutter, where you can show suggestions to
 users as they type
 
 <img src="https://raw.githubusercontent.com/AbdulRahmanAlHamali/flutter_typeahead/master/flutter_typeahead.gif">
 
 ## Features
-* Shows suggestions in an overlay that floats on top of other widgets
-* Allows you to specify what the suggestions will look like through a
-builder function
-* Allows you to specify what happens when the user taps a suggestion
-* Accepts all the parameters that traditional TextFields accept, like
-decoration, custom TextEditingController, text styling, etc.
-* Provides two versions, a normal version and a [FormField](https://docs.flutter.io/flutter/widgets/FormField-class.html)
-version that accepts validation, submitting, etc.
-* Provides high customizable; you can customize the suggestion box decoration,
-the loading bar, the animation, the debounce duration, etc.
+
+- Shows suggestions in an overlay that floats on top of other widgets
+- Allows you to specify what the suggestions will look like through a
+  builder function
+- Allows you to specify what happens when the user taps a suggestion
+- Accepts all the parameters that traditional TextFields accept, like
+  decoration, custom TextEditingController, text styling, etc.
+- Provides two versions, a normal version and a [FormField](https://docs.flutter.io/flutter/widgets/FormField-class.html)
+  version that accepts validation, submitting, etc.
+- Provides high customizable; you can customize the suggestion box decoration,
+  the loading bar, the animation, the debounce duration, etc.
 
 ## Installation
+
 See the [installation instructions on pub](https://pub.dartlang.org/packages/flutter_typeahead#-installing-tab-).
 
-Note: As for Typeahead 3.X this package is based on Dart 2.12 (null-safety). You may also want to explore the new built in Flutter 2 widgets that have similar behavior. 
+Note: As for Typeahead 3.X this package is based on Dart 2.12 (null-safety). You may also want to explore the new built in Flutter 2 widgets that have similar behavior.
 
 ## Usage examples
+
 You can import the package with:
+
 ```dart
 import 'package:flutter_typeahead/flutter_typeahead.dart';
 ```
 
 For Cupertino users import:
+
 ```dart
 import 'package:flutter_typeahead/cupertino_flutter_typeahead.dart';
 ```
@@ -39,6 +45,7 @@ import 'package:flutter_typeahead/cupertino_flutter_typeahead.dart';
 Use it as follows:
 
 ### Material Example 1:
+
 ```dart
 TypeAheadField(
   textFieldConfiguration: TextFieldConfiguration(
@@ -67,6 +74,7 @@ TypeAheadField(
   },
 )
 ```
+
 In the code above, the `textFieldConfiguration` property allows us to
 configure the displayed `TextField` as we want. In this example, we are
 configuring the `autofocus`, `style` and `decoration` properties.
@@ -88,7 +96,9 @@ suggestion, we navigate to a page that shows us the information of the
 tapped product.
 
 ### Material Example 2:
+
 Here's another example, where we use the TypeAheadFormField inside a `Form`:
+
 ```dart
 final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 final TextEditingController _typeAheadController = TextEditingController();
@@ -109,7 +119,7 @@ Form(
             decoration: InputDecoration(
               labelText: 'City'
             )
-          ),          
+          ),
           suggestionsCallback: (pattern) {
             return CitiesService.getSuggestions(pattern);
           },
@@ -148,6 +158,7 @@ Form(
   ),
 )
 ```
+
 Here, we assign to the `controller` property of the `textFieldConfiguration`
 a `TextEditingController` that we call `_typeAheadController`.
 We use this controller in the `onSuggestionSelected` callback to set the
@@ -162,17 +173,46 @@ The `transitionBuilder` allows us to customize the animation of the
 suggestion box. In this example, we are returning the suggestionsBox
 immediately, meaning that we don't want any animation.
 
+### Material with Alternative Layout Architecture:
+
+By default, TypeAhead uses a `ListView` to render the items created by `itemBuilder`. If you specify a `layoutArchitecture` component, it will use this component instead. For example, here's how we render the items in a grid using the standard `GridView`:
+
+```dart
+TypeAheadField(
+    ...,
+  layoutArchitecture: (items, scrollContoller) {
+        return ListView(
+            controller: scrollContoller,
+            shrinkWrap: true,
+            children: [
+              GridView.count(
+                physics: const ScrollPhysics(),
+                crossAxisCount: 3,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+                childAspectRatio: 5 / 5,
+                shrinkWrap: true,
+                children: items.toList(),
+              ),
+            ]);
+      },
+);
+```
+
 ### Cupertino Example:
+
 Please see the Cupertino code in the example project.
 
 ## Known Issues
 
 ### Animations
-Placing TypeAheadField in widgets with animations may cause the suggestions box 
-to resize incorrectly. Since animation times are variable, this has to be 
-corrected manually at the end of the animation. You will need to add a 
-SuggestionsBoxController described below and the following code for the 
+
+Placing TypeAheadField in widgets with animations may cause the suggestions box
+to resize incorrectly. Since animation times are variable, this has to be
+corrected manually at the end of the animation. You will need to add a
+SuggestionsBoxController described below and the following code for the
 AnimationController.
+
 ```dart
 void Function(AnimationStatus) _statusListener;
 
@@ -198,16 +238,20 @@ void initState() {
 ```
 
 #### Dialogs
+
 There is a known issue with opening dialogs where the suggestions box will sometimes appear too small. This is a timing issue caused by the animations described above. Currently, `showDialog` has a duration of 150 ms for the animations. TypeAheadField has a delay of 170 ms to compensate for this. Until the end of the animation can be properly detected and fixed using the solution above, this temporary fix will work most of the time. If the suggestions box is too small, closing and reopening the keyboard will usually fix the issue.
 
 ### Cupertino
+
 The Cupertino classes in TypeAhead are still new. There are also differences in the Cupertino widgets vs the Material ones. Some behavior will not translate when moving between the two.
 
 ## Customizations
+
 TypeAhead widgets consist of a TextField and a suggestion box that shows
 as the user types. Both are highly customizable
 
 ### Customizing the TextField
+
 You can customize the text field using the `textFieldConfiguration` property.
 You provide this property with an instance of `TextFieldConfiguration`,
 which allows you to configure all the usual properties of `TextField`, like
@@ -215,19 +259,22 @@ which allows you to configure all the usual properties of `TextField`, like
 etc.
 
 ### Customizing the suggestions box
+
 TypeAhead provides default configurations for the suggestions box. You can,
-however, override most of them. This is done by passing a `SuggestionsBoxDecoration` 
+however, override most of them. This is done by passing a `SuggestionsBoxDecoration`
 to the `suggestionsBoxDecoration` property.
 
-Use the `offsetX` property in `SuggestionsBoxDecoration` to shift the suggestions box along the x-axis. 
-You may also pass BoxConstraints to `constraints` in `SuggestionsBoxDecoration` to adjust the width 
-and height of the suggestions box. Using the two together will allow the suggestions box to be placed 
+Use the `offsetX` property in `SuggestionsBoxDecoration` to shift the suggestions box along the x-axis.
+You may also pass BoxConstraints to `constraints` in `SuggestionsBoxDecoration` to adjust the width
+and height of the suggestions box. Using the two together will allow the suggestions box to be placed
 almost anywhere.
 
 #### Customizing the loader, the error and the "no items found" message
+
 You can use the `loadingBuilder`, `errorBuilder` and `noItemsFoundBuilder` to
 customize their corresponding widgets. For example, to show a custom error
 widget:
+
 ```dart
 errorBuilder: (BuildContext context, Object error) =>
   Text(
@@ -238,23 +285,25 @@ errorBuilder: (BuildContext context, Object error) =>
   )
 ```
 
-By default, the suggestions box will maintain the old suggestions while new 
-suggestions are being retrieved. To show a circular progress indicator 
+By default, the suggestions box will maintain the old suggestions while new
+suggestions are being retrieved. To show a circular progress indicator
 during retrieval instead, set `keepSuggestionsOnLoading` to false.
 
 #### Hiding the suggestions box
+
 There are three scenarios when you can hide the suggestions box.
 
-Set `hideOnLoading` to true to hide the box while suggestions are being 
-retrieved. This will also ignore the `loadingBuilder`. Set `hideOnEmpty` 
-to true to hide the box when there are no suggestions. This will also ignore 
-the `noItemsFoundBuilder`. Set `hideOnError` to true to hide the box when there 
+Set `hideOnLoading` to true to hide the box while suggestions are being
+retrieved. This will also ignore the `loadingBuilder`. Set `hideOnEmpty`
+to true to hide the box when there are no suggestions. This will also ignore
+the `noItemsFoundBuilder`. Set `hideOnError` to true to hide the box when there
 is an error retrieving suggestions. This will also ignore the `errorBuilder`.
 
-By default, the suggestions box will automatically hide when the keyboard is hidden. 
+By default, the suggestions box will automatically hide when the keyboard is hidden.
 To change this behavior, set `hideSuggestionsOnKeyboardHide` to false.
 
 #### Customizing the animation
+
 You can customize the suggestion box animation through 3 parameters: the
 `animationDuration`, the `animationStart`, and the `transitionBuilder`.
 
@@ -264,6 +313,7 @@ should start from. The `transitionBuilder` accepts the `suggestionsBox` and
 `animationController` as parameters, and should return a widget that uses
 the `animationController` to animate the display of the `suggestionsBox`.
 For example:
+
 ```dart
 transitionBuilder: (context, suggestionsBox, animationController) =>
   FadeTransition(
@@ -274,6 +324,7 @@ transitionBuilder: (context, suggestionsBox, animationController) =>
     ),
   )
 ```
+
 This uses [FadeTransition](https://docs.flutter.io/flutter/widgets/FadeTransition-class.html)
 to fade the `suggestionsBox` into the view. Note how the
 `animationController` was provided as the parent of the animation.
@@ -283,19 +334,23 @@ return the `suggestionsBox`. This callback could also be used to wrap the
 `suggestionsBox` with any desired widgets, not necessarily for animation.
 
 #### Customizing the debounce duration
+
 The suggestions box does not fire for each character the user types. Instead,
 we wait until the user is idle for a duration of time, and then call the
 `suggestionsCallback`. The duration defaults to 300 milliseconds, but can be
 configured using the `debounceDuration` parameter.
 
 #### Customizing the offset of the suggestions box
+
 By default, the suggestions box is displayed 5 pixels below the `TextField`.
 You can change this by changing the `suggestionsBoxVerticalOffset` property.
 
 #### Customizing the decoration of the suggestions box
+
 You can also customize the decoration of the suggestions box using the
 `suggestionsBoxDecoration` property. For example, to remove the elevation
 of the suggestions box, you can write:
+
 ```dart
 suggestionsBoxDecoration: SuggestionsBoxDecoration(
   elevation: 0.0
@@ -303,25 +358,31 @@ suggestionsBoxDecoration: SuggestionsBoxDecoration(
 ```
 
 #### Customizing the growth direction of the suggestions list
+
 By default, the list grows towards the bottom. However, you can use the `direction` property to customize the growth direction to be one of `AxisDirection.down` or `AxisDirection.up`, the latter of which will cause the list to grow up, where the first suggestion is at the bottom of the list, and the last suggestion is at the top.
 
 Set `autoFlipDirection` to true to allow the suggestions list to automatically flip direction whenever it detects that there is not enough space for the current direction. This is useful for scenarios where the TypeAheadField is in a scrollable widget or when the developer wants to ensure the list is always viewable despite different user screen sizes.
 
 #### Controlling the suggestions box
-Manual control of the suggestions box can be achieved by creating an instance of `SuggestionsBoxController` and 
-passing it to the `suggestionsBoxController` property. This will allow you to manually open, close, toggle, or 
+
+Manual control of the suggestions box can be achieved by creating an instance of `SuggestionsBoxController` and
+passing it to the `suggestionsBoxController` property. This will allow you to manually open, close, toggle, or
 resize the suggestions box.
 
 ## For more information
+
 Visit the [API Documentation](https://pub.dartlang.org/documentation/flutter_typeahead/latest/)
 
 ## Team:
-| [<img src="https://avatars.githubusercontent.com/u/16646600?v=3" width="100px;"/>](https://github.com/AbdulRahmanAlHamali)|[<img src="https://avatars.githubusercontent.com/u/2034925?v=3" width="100px;"/>](https://github.com/sjmcdowall)|[<img src="https://avatars.githubusercontent.com/u/5499214?v=3" width="100px;"/>](https://github.com/KaYBlitZ)|
-|---|---|---|
-|AbdulRahman AlHamali|S McDowall|Kenneth Liang|
+
+| [<img src="https://avatars.githubusercontent.com/u/16646600?v=3" width="100px;"/>](https://github.com/AbdulRahmanAlHamali) | [<img src="https://avatars.githubusercontent.com/u/2034925?v=3" width="100px;"/>](https://github.com/sjmcdowall) | [<img src="https://avatars.githubusercontent.com/u/5499214?v=3" width="100px;"/>](https://github.com/KaYBlitZ) |
+| -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| AbdulRahman AlHamali                                                                                                       | S McDowall                                                                                                       | Kenneth Liang                                                                                                  |
 
 ## Shout out to the contributors!
+
 This project is the result of the collective effort of contributors who participated effectively by submitting pull requests, reporting issues, and answering questions. Thank you for your proactiveness, and we hope flutter_typeahead made your lifes at least a little easier!
 
 ## How you can help
+
 [Contribution Guidelines](https://github.com/AbdulRahmanAlHamali/flutter_typeahead/blob/master/CONTRIBUTING.md)

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -227,6 +227,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -23,10 +23,10 @@ class _MyAppState extends State<MyApp> {
     if (!isCupertino) {
       return MaterialApp(
         title: 'flutter_typeahead demo',
-        scrollBehavior:
-            MaterialScrollBehavior().copyWith(dragDevices: {PointerDeviceKind.mouse, PointerDeviceKind.touch}),
+        scrollBehavior: MaterialScrollBehavior().copyWith(
+            dragDevices: {PointerDeviceKind.mouse, PointerDeviceKind.touch}),
         home: DefaultTabController(
-          length: 3,
+          length: 4,
           child: Scaffold(
               appBar: AppBar(
                 leading: IconButton(
@@ -36,9 +36,10 @@ class _MyAppState extends State<MyApp> {
                   }),
                 ),
                 title: TabBar(tabs: [
-                  Tab(text: 'Example 1: Navigation'),
-                  Tab(text: 'Example 2: Form'),
-                  Tab(text: 'Example 3: Scroll')
+                  Tab(text: '1: Navigation'),
+                  Tab(text: '2: Form'),
+                  Tab(text: '3: Scroll'),
+                  Tab(text: '4: Alteranative Layou')
                 ]),
               ),
               body: GestureDetector(
@@ -47,6 +48,7 @@ class _MyAppState extends State<MyApp> {
                   NavigationExample(),
                   FormExample(),
                   ScrollExample(),
+                  AlternativeLayoutArchitecture(),
                 ]),
               )),
         ),
@@ -86,8 +88,12 @@ class NavigationExample extends StatelessWidget {
           TypeAheadField(
             textFieldConfiguration: TextFieldConfiguration(
               autofocus: true,
-              style: DefaultTextStyle.of(context).style.copyWith(fontStyle: FontStyle.italic),
-              decoration: InputDecoration(border: OutlineInputBorder(), hintText: 'What are you looking for?'),
+              style: DefaultTextStyle.of(context)
+                  .style
+                  .copyWith(fontStyle: FontStyle.italic),
+              decoration: InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'What are you looking for?'),
             ),
             suggestionsCallback: (pattern) async {
               return await BackendService.getSuggestions(pattern);
@@ -100,8 +106,8 @@ class NavigationExample extends StatelessWidget {
               );
             },
             onSuggestionSelected: (Map<String, String> suggestion) {
-              Navigator.of(context)
-                  .push<void>(MaterialPageRoute(builder: (context) => ProductPage(product: suggestion)));
+              Navigator.of(context).push<void>(MaterialPageRoute(
+                  builder: (context) => ProductPage(product: suggestion)));
             },
             suggestionsBoxDecoration: SuggestionsBoxDecoration(
               borderRadius: BorderRadius.circular(10.0),
@@ -166,7 +172,8 @@ class _FormExampleState extends State<FormExample> {
                     this._typeAheadController.text = suggestion;
                   },
                   suggestionsBoxController: suggestionBoxController,
-                  validator: (value) => value!.isEmpty ? 'Please select a city' : null,
+                  validator: (value) =>
+                      value!.isEmpty ? 'Please select a city' : null,
                   onSaved: (value) => this._selectedCity = value,
                 ),
                 Spacer(),
@@ -177,7 +184,8 @@ class _FormExampleState extends State<FormExample> {
                       this._formKey.currentState!.save();
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: Text('Your Favorite City is ${this._selectedCity}'),
+                          content: Text(
+                              'Your Favorite City is ${this._selectedCity}'),
                         ),
                       );
                     }
@@ -238,10 +246,15 @@ class ScrollExample extends StatelessWidget {
       TypeAheadField<String>(
         getImmediateSuggestions: true,
         textFieldConfiguration: TextFieldConfiguration(
-          decoration: InputDecoration(border: OutlineInputBorder(), hintText: 'What are you looking for?'),
+          decoration: InputDecoration(
+              border: OutlineInputBorder(),
+              hintText: 'What are you looking for?'),
         ),
         suggestionsCallback: (String pattern) async {
-          return items.where((item) => item.toLowerCase().startsWith(pattern.toLowerCase())).toList();
+          return items
+              .where((item) =>
+                  item.toLowerCase().startsWith(pattern.toLowerCase()))
+              .toList();
         },
         itemBuilder: (context, String suggestion) {
           return ListTile(
@@ -265,7 +278,10 @@ class BackendService {
     await Future<void>.delayed(Duration(seconds: 1));
 
     return List.generate(3, (index) {
-      return {'name': query + index.toString(), 'price': Random().nextInt(100).toString()};
+      return {
+        'name': query + index.toString(),
+        'price': Random().nextInt(100).toString()
+      };
     });
   }
 }
@@ -305,7 +321,8 @@ class FavoriteCitiesPage extends StatefulWidget {
 class _FavoriteCitiesPage extends State<FavoriteCitiesPage> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _typeAheadController = TextEditingController();
-  CupertinoSuggestionsBoxController _suggestionsBoxController = CupertinoSuggestionsBoxController();
+  CupertinoSuggestionsBoxController _suggestionsBoxController =
+      CupertinoSuggestionsBoxController();
   String favoriteCity = 'Unavailable';
 
   @override
@@ -350,7 +367,8 @@ class _FavoriteCitiesPage extends State<FavoriteCitiesPage> {
                   onSuggestionSelected: (String suggestion) {
                     _typeAheadController.text = suggestion;
                   },
-                  validator: (value) => value!.isEmpty ? 'Please select a city' : null,
+                  validator: (value) =>
+                      value!.isEmpty ? 'Please select a city' : null,
                 ),
                 SizedBox(
                   height: 10.0,
@@ -377,6 +395,69 @@ class _FavoriteCitiesPage extends State<FavoriteCitiesPage> {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class AlternativeLayoutArchitecture extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.all(32.0),
+      child: Column(
+        children: <Widget>[
+          SizedBox(
+            height: 10.0,
+          ),
+          TypeAheadField(
+            textFieldConfiguration: TextFieldConfiguration(
+              autofocus: true,
+              style: DefaultTextStyle.of(context)
+                  .style
+                  .copyWith(fontStyle: FontStyle.italic),
+              decoration: InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'What are you looking for?'),
+            ),
+            suggestionsCallback: (pattern) async {
+              return await BackendService.getSuggestions(pattern);
+            },
+            itemBuilder: (context, Map<String, String> suggestion) {
+              return ListTile(
+                tileColor: Theme.of(context).colorScheme.secondaryContainer,
+                leading: Icon(Icons.shopping_cart),
+                title: Text(suggestion['name']!),
+                subtitle: Text('\$${suggestion['price']}'),
+              );
+            },
+            layoutArchitecture: (items, scrollContoller) {
+              return ListView(
+                  controller: scrollContoller,
+                  shrinkWrap: true,
+                  children: [
+                    GridView.count(
+                      physics: const ScrollPhysics(),
+                      crossAxisCount: 2,
+                      crossAxisSpacing: 8,
+                      mainAxisSpacing: 8,
+                      childAspectRatio: 5 / 5,
+                      shrinkWrap: true,
+                      children: items.toList(),
+                    ),
+                  ]);
+            },
+            onSuggestionSelected: (Map<String, String> suggestion) {
+              Navigator.of(context).push<void>(MaterialPageRoute(
+                  builder: (context) => ProductPage(product: suggestion)));
+            },
+            suggestionsBoxDecoration: SuggestionsBoxDecoration(
+              borderRadius: BorderRadius.circular(10.0),
+              elevation: 8.0,
+              color: Theme.of(context).cardColor,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/material/field/typeahead_field.dart
+++ b/lib/src/material/field/typeahead_field.dart
@@ -308,6 +308,12 @@ class TypeAheadField<T> extends StatefulWidget {
   /// ```
   final ItemBuilder<T> itemBuilder;
 
+  /// By default, we render the suggestions in a ListView, using
+  /// the `itemBuilder` to construct each element of the list.  Specify
+  /// your own `layoutArchitecture` if you want to be responsible
+  /// for layinng out the widgets using some other system (like a grid).
+  final LayoutArchitecture? layoutArchitecture;
+
   /// used to control the scroll behavior of item-builder list
   final ScrollController? scrollController;
 
@@ -529,6 +535,7 @@ class TypeAheadField<T> extends StatefulWidget {
   TypeAheadField({
     required this.suggestionsCallback,
     required this.itemBuilder,
+    this.layoutArchitecture,
     required this.onSuggestionSelected,
     this.textFieldConfiguration = const TextFieldConfiguration(),
     this.suggestionsBoxDecoration = const SuggestionsBoxDecoration(),
@@ -772,6 +779,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
             widget.onSuggestionSelected(selection);
           },
           itemBuilder: widget.itemBuilder,
+          layoutArchitecture: widget.layoutArchitecture,
           direction: _suggestionsBox!.direction,
           hideOnLoading: widget.hideOnLoading,
           hideOnEmpty: widget.hideOnEmpty,

--- a/lib/src/material/field/typeahead_form_field.dart
+++ b/lib/src/material/field/typeahead_form_field.dart
@@ -5,7 +5,6 @@ import 'package:flutter_typeahead/src/material/suggestions_box/suggestions_box_c
 import 'package:flutter_typeahead/src/material/suggestions_box/suggestions_box_decoration.dart';
 import 'package:flutter_typeahead/src/typedef.dart';
 
-
 /// A [FormField](https://docs.flutter.io/flutter/widgets/FormField-class.html)
 /// implementation of [TypeAheadField], that allows the value to be saved,
 /// validated, etc.
@@ -25,103 +24,105 @@ class TypeAheadFormField<T> extends FormField<String> {
   /// Creates a [TypeAheadFormField]
   TypeAheadFormField(
       {Key? key,
-        String? initialValue,
-        bool getImmediateSuggestions = false,
-        @Deprecated('Use autovalidateMode parameter which provides more specific '
-            'behavior related to auto validation. '
-            'This feature was deprecated after Flutter v1.19.0.')
-        bool autovalidate = false,
-        bool enabled = true,
-        AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
-        FormFieldSetter<String>? onSaved,
-        this.onReset,
-        FormFieldValidator<String>? validator,
-        ErrorBuilder? errorBuilder,
-        WidgetBuilder? noItemsFoundBuilder,
-        WidgetBuilder? loadingBuilder,
-        void Function(bool)? onSuggestionsBoxToggle,
-        Duration debounceDuration = const Duration(milliseconds: 300),
-        SuggestionsBoxDecoration suggestionsBoxDecoration =
-        const SuggestionsBoxDecoration(),
-        SuggestionsBoxController? suggestionsBoxController,
-        required SuggestionSelectionCallback<T> onSuggestionSelected,
-        required ItemBuilder<T> itemBuilder,
-        required SuggestionsCallback<T> suggestionsCallback,
-        double suggestionsBoxVerticalOffset = 5.0,
-        this.textFieldConfiguration = const TextFieldConfiguration(),
-        AnimationTransitionBuilder? transitionBuilder,
-        Duration animationDuration = const Duration(milliseconds: 500),
-        double animationStart = 0.25,
-        AxisDirection direction = AxisDirection.down,
-        bool hideOnLoading = false,
-        bool hideOnEmpty = false,
-        bool hideOnError = false,
-        bool hideSuggestionsOnKeyboardHide = true,
-        bool keepSuggestionsOnLoading = true,
-        bool keepSuggestionsOnSuggestionSelected = false,
-        bool autoFlipDirection = false,
-        bool autoFlipListDirection = true,
-        double autoFlipMinHeight = 64.0,
-        bool hideKeyboard = false,
-        int minCharsForSuggestions = 0,
-        bool hideKeyboardOnDrag = false})
+      String? initialValue,
+      bool getImmediateSuggestions = false,
+      @Deprecated('Use autovalidateMode parameter which provides more specific '
+          'behavior related to auto validation. '
+          'This feature was deprecated after Flutter v1.19.0.')
+      bool autovalidate = false,
+      bool enabled = true,
+      AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
+      FormFieldSetter<String>? onSaved,
+      this.onReset,
+      FormFieldValidator<String>? validator,
+      ErrorBuilder? errorBuilder,
+      WidgetBuilder? noItemsFoundBuilder,
+      WidgetBuilder? loadingBuilder,
+      void Function(bool)? onSuggestionsBoxToggle,
+      Duration debounceDuration = const Duration(milliseconds: 300),
+      SuggestionsBoxDecoration suggestionsBoxDecoration =
+          const SuggestionsBoxDecoration(),
+      SuggestionsBoxController? suggestionsBoxController,
+      required SuggestionSelectionCallback<T> onSuggestionSelected,
+      required ItemBuilder<T> itemBuilder,
+      LayoutArchitecture? layoutArchitecture,
+      required SuggestionsCallback<T> suggestionsCallback,
+      double suggestionsBoxVerticalOffset = 5.0,
+      this.textFieldConfiguration = const TextFieldConfiguration(),
+      AnimationTransitionBuilder? transitionBuilder,
+      Duration animationDuration = const Duration(milliseconds: 500),
+      double animationStart = 0.25,
+      AxisDirection direction = AxisDirection.down,
+      bool hideOnLoading = false,
+      bool hideOnEmpty = false,
+      bool hideOnError = false,
+      bool hideSuggestionsOnKeyboardHide = true,
+      bool keepSuggestionsOnLoading = true,
+      bool keepSuggestionsOnSuggestionSelected = false,
+      bool autoFlipDirection = false,
+      bool autoFlipListDirection = true,
+      double autoFlipMinHeight = 64.0,
+      bool hideKeyboard = false,
+      int minCharsForSuggestions = 0,
+      bool hideKeyboardOnDrag = false})
       : assert(
-  initialValue == null || textFieldConfiguration.controller == null),
+            initialValue == null || textFieldConfiguration.controller == null),
         assert(minCharsForSuggestions >= 0),
         super(
-          key: key,
-          onSaved: onSaved,
-          validator: validator,
-          initialValue: textFieldConfiguration.controller != null
-              ? textFieldConfiguration.controller!.text
-              : (initialValue ?? ''),
-          enabled: enabled,
-          autovalidateMode: autovalidateMode,
-          builder: (FormFieldState<String> field) {
-            final _TypeAheadFormFieldState state =
-            field as _TypeAheadFormFieldState<dynamic>;
+            key: key,
+            onSaved: onSaved,
+            validator: validator,
+            initialValue: textFieldConfiguration.controller != null
+                ? textFieldConfiguration.controller!.text
+                : (initialValue ?? ''),
+            enabled: enabled,
+            autovalidateMode: autovalidateMode,
+            builder: (FormFieldState<String> field) {
+              final _TypeAheadFormFieldState state =
+                  field as _TypeAheadFormFieldState<dynamic>;
 
-            return TypeAheadField(
-              getImmediateSuggestions: getImmediateSuggestions,
-              transitionBuilder: transitionBuilder,
-              errorBuilder: errorBuilder,
-              noItemsFoundBuilder: noItemsFoundBuilder,
-              loadingBuilder: loadingBuilder,
-              debounceDuration: debounceDuration,
-              suggestionsBoxDecoration: suggestionsBoxDecoration,
-              suggestionsBoxController: suggestionsBoxController,
-              textFieldConfiguration: textFieldConfiguration.copyWith(
-                decoration: textFieldConfiguration.decoration
-                    .copyWith(errorText: state.errorText),
-                onChanged: (text) {
-                  state.didChange(text);
-                  textFieldConfiguration.onChanged?.call(text);
-                },
-                controller: state._effectiveController,
-              ),
-              suggestionsBoxVerticalOffset: suggestionsBoxVerticalOffset,
-              onSuggestionSelected: onSuggestionSelected,
-              onSuggestionsBoxToggle: onSuggestionsBoxToggle,
-              itemBuilder: itemBuilder,
-              suggestionsCallback: suggestionsCallback,
-              animationStart: animationStart,
-              animationDuration: animationDuration,
-              direction: direction,
-              hideOnLoading: hideOnLoading,
-              hideOnEmpty: hideOnEmpty,
-              hideOnError: hideOnError,
-              hideSuggestionsOnKeyboardHide: hideSuggestionsOnKeyboardHide,
-              keepSuggestionsOnLoading: keepSuggestionsOnLoading,
-              keepSuggestionsOnSuggestionSelected:
-              keepSuggestionsOnSuggestionSelected,
-              autoFlipDirection: autoFlipDirection,
-              autoFlipListDirection: autoFlipListDirection,
-              autoFlipMinHeight: autoFlipMinHeight,
-              hideKeyboard: hideKeyboard,
-              minCharsForSuggestions: minCharsForSuggestions,
-              hideKeyboardOnDrag: hideKeyboardOnDrag,
-            );
-          });
+              return TypeAheadField(
+                getImmediateSuggestions: getImmediateSuggestions,
+                transitionBuilder: transitionBuilder,
+                errorBuilder: errorBuilder,
+                noItemsFoundBuilder: noItemsFoundBuilder,
+                loadingBuilder: loadingBuilder,
+                debounceDuration: debounceDuration,
+                suggestionsBoxDecoration: suggestionsBoxDecoration,
+                suggestionsBoxController: suggestionsBoxController,
+                textFieldConfiguration: textFieldConfiguration.copyWith(
+                  decoration: textFieldConfiguration.decoration
+                      .copyWith(errorText: state.errorText),
+                  onChanged: (text) {
+                    state.didChange(text);
+                    textFieldConfiguration.onChanged?.call(text);
+                  },
+                  controller: state._effectiveController,
+                ),
+                suggestionsBoxVerticalOffset: suggestionsBoxVerticalOffset,
+                onSuggestionSelected: onSuggestionSelected,
+                onSuggestionsBoxToggle: onSuggestionsBoxToggle,
+                itemBuilder: itemBuilder,
+                layoutArchitecture: layoutArchitecture,
+                suggestionsCallback: suggestionsCallback,
+                animationStart: animationStart,
+                animationDuration: animationDuration,
+                direction: direction,
+                hideOnLoading: hideOnLoading,
+                hideOnEmpty: hideOnEmpty,
+                hideOnError: hideOnError,
+                hideSuggestionsOnKeyboardHide: hideSuggestionsOnKeyboardHide,
+                keepSuggestionsOnLoading: keepSuggestionsOnLoading,
+                keepSuggestionsOnSuggestionSelected:
+                    keepSuggestionsOnSuggestionSelected,
+                autoFlipDirection: autoFlipDirection,
+                autoFlipListDirection: autoFlipListDirection,
+                autoFlipMinHeight: autoFlipMinHeight,
+                hideKeyboard: hideKeyboard,
+                minCharsForSuggestions: minCharsForSuggestions,
+                hideKeyboardOnDrag: hideKeyboardOnDrag,
+              );
+            });
 
   @override
   _TypeAheadFormFieldState<T> createState() => _TypeAheadFormFieldState<T>();

--- a/lib/src/typedef.dart
+++ b/lib/src/typedef.dart
@@ -9,3 +9,6 @@ typedef Widget ErrorBuilder(BuildContext context, Object? error);
 
 typedef Widget AnimationTransitionBuilder(
     BuildContext context, Widget child, AnimationController? controller);
+
+typedef LayoutArchitecture = Widget Function(
+    Iterable<Widget> items, ScrollController controller);


### PR DESCRIPTION
Currently, TypeAhead is hard-wired to only layout items built with `itemBuilder` in a `ListView`.  This pull request extends TypeAhead with an optional `layoutArchitecture`.  If it's present, it will use that, instead of the `ListView`.  This video demonstrates the change in action:


https://github.com/AbdulRahmanAlHamali/flutter_typeahead/assets/545244/16728e02-eb17-4f4f-8dc6-c54b0d914342

I've also modified the example app.  The key is a new parameter which has this type:

```dart
typedef LayoutArchitecture = Widget Function(
    Iterable<Widget> items, ScrollController controller);
```

Here's how I use it:

```dart
TypeAhead(
... etc,
layoutArchitecture: (items, scrollContoller) {
        return ListView(
            controller: scrollContoller,
            shrinkWrap: true,
            children: [
              GridView.count(
                physics: const ScrollPhysics(),
                crossAxisCount: 3,
                crossAxisSpacing: 8,
                mainAxisSpacing: 8,
                childAspectRatio: 5 / 5,
                shrinkWrap: true,
                children: items.toList(),
              ),
            ]);
      },
)
```