### PR TITLE
Support alternative (for example Grid) layouts of results

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,36 @@ The `transitionBuilder` allows us to customize the animation of the
 suggestion box. In this example, we are returning the suggestionsBox
 immediately, meaning that we don't want any animation.
 
+### Material with Alternative Layout Architecture:
+
+By default, TypeAhead uses a `ListView` to render the items created by `itemBuilder`. If you specify a `layoutArchitecture` component, it will use this component instead. For example, here's how we render the items in a grid using the standard `GridView`:
+
+```dart
+TypeAheadField(
+    ...,
+  layoutArchitecture: (items, scrollContoller) {
+        return ListView(
+            controller: scrollContoller,
+            shrinkWrap: true,
+            children: [
+              GridView.count(
+                physics: const ScrollPhysics(),
+                crossAxisCount: 3,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+                childAspectRatio: 5 / 5,
+                shrinkWrap: true,
+                children: items.toList(),
+              ),
+            ]);
+      },
+);
+```
+
+### Cupertino Example:
+
+
+
 ### Cupertino Example:
 Please see the Cupertino code in the example project.
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,7 +26,7 @@ class _MyAppState extends State<MyApp> {
         scrollBehavior: MaterialScrollBehavior().copyWith(
             dragDevices: {PointerDeviceKind.mouse, PointerDeviceKind.touch}),
         home: DefaultTabController(
-          length: 3,
+          length: 4,
           child: Scaffold(
               appBar: AppBar(
                 leading: IconButton(
@@ -38,7 +38,8 @@ class _MyAppState extends State<MyApp> {
                 title: TabBar(tabs: [
                   Tab(text: 'Example 1: Navigation'),
                   Tab(text: 'Example 2: Form'),
-                  Tab(text: 'Example 3: Scroll')
+                  Tab(text: 'Example 3: Scroll'),
+                  Tab(text: '4: Alternative Layout')
                 ]),
               ),
               body: GestureDetector(
@@ -47,6 +48,7 @@ class _MyAppState extends State<MyApp> {
                   NavigationExample(),
                   FormExample(),
                   ScrollExample(),
+                  AlternativeLayoutArchitecture(),
                 ]),
               )),
         ),
@@ -406,6 +408,69 @@ class _FavoriteCitiesPage extends State<FavoriteCitiesPage> {
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class AlternativeLayoutArchitecture extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.all(32.0),
+      child: Column(
+        children: <Widget>[
+          SizedBox(
+            height: 10.0,
+          ),
+          TypeAheadField(
+            textFieldConfiguration: TextFieldConfiguration(
+              autofocus: true,
+              style: DefaultTextStyle.of(context)
+                  .style
+                  .copyWith(fontStyle: FontStyle.italic),
+              decoration: InputDecoration(
+                  border: OutlineInputBorder(),
+                  hintText: 'What are you looking for?'),
+            ),
+            suggestionsCallback: (pattern) async {
+              return await BackendService.getSuggestions(pattern);
+            },
+            itemBuilder: (context, Map<String, String> suggestion) {
+              return ListTile(
+                tileColor: Theme.of(context).colorScheme.secondaryContainer,
+                leading: Icon(Icons.shopping_cart),
+                title: Text(suggestion['name']!),
+                subtitle: Text('\$${suggestion['price']}'),
+              );
+            },
+            layoutArchitecture: (items, scrollContoller) {
+              return ListView(
+                  controller: scrollContoller,
+                  shrinkWrap: true,
+                  children: [
+                    GridView.count(
+                      physics: const ScrollPhysics(),
+                      crossAxisCount: 2,
+                      crossAxisSpacing: 8,
+                      mainAxisSpacing: 8,
+                      childAspectRatio: 5 / 5,
+                      shrinkWrap: true,
+                      children: items.toList(),
+                    ),
+                  ]);
+            },
+            onSuggestionSelected: (Map<String, String> suggestion) {
+              Navigator.of(context).push<void>(MaterialPageRoute(
+                  builder: (context) => ProductPage(product: suggestion)));
+            },
+            suggestionsBoxDecoration: SuggestionsBoxDecoration(
+              borderRadius: BorderRadius.circular(10.0),
+              elevation: 8.0,
+              color: Theme.of(context).cardColor,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/material/field/typeahead_field.dart
+++ b/lib/src/material/field/typeahead_field.dart
@@ -309,6 +309,12 @@ class TypeAheadField<T> extends StatefulWidget {
   final ItemBuilder<T> itemBuilder;
   final IndexedWidgetBuilder? itemSeparatorBuilder;
 
+  /// By default, we render the suggestions in a ListView, using
+  /// the `itemBuilder` to construct each element of the list.  Specify
+  /// your own `layoutArchitecture` if you want to be responsible
+  /// for layinng out the widgets using some other system (like a grid).
+  final LayoutArchitecture? layoutArchitecture;
+
   /// used to control the scroll behavior of item-builder list
   final ScrollController? scrollController;
 
@@ -531,6 +537,7 @@ class TypeAheadField<T> extends StatefulWidget {
     required this.suggestionsCallback,
     required this.itemBuilder,
     this.itemSeparatorBuilder,
+    this.layoutArchitecture,
     required this.onSuggestionSelected,
     this.textFieldConfiguration = const TextFieldConfiguration(),
     this.suggestionsBoxDecoration = const SuggestionsBoxDecoration(),
@@ -775,6 +782,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
           },
           itemBuilder: widget.itemBuilder,
           itemSeparatorBuilder: widget.itemSeparatorBuilder,
+          layoutArchitecture: widget.layoutArchitecture,
           direction: _suggestionsBox!.direction,
           hideOnLoading: widget.hideOnLoading,
           hideOnEmpty: widget.hideOnEmpty,

--- a/lib/src/material/field/typeahead_form_field.dart
+++ b/lib/src/material/field/typeahead_form_field.dart
@@ -46,6 +46,7 @@ class TypeAheadFormField<T> extends FormField<String> {
       required SuggestionSelectionCallback<T> onSuggestionSelected,
       required ItemBuilder<T> itemBuilder,
       IndexedWidgetBuilder? itemSeparatorBuilder,
+      LayoutArchitecture? layoutArchitecture,
       required SuggestionsCallback<T> suggestionsCallback,
       double suggestionsBoxVerticalOffset = 5.0,
       this.textFieldConfiguration = const TextFieldConfiguration(),
@@ -103,7 +104,7 @@ class TypeAheadFormField<T> extends FormField<String> {
                 onSuggestionSelected: onSuggestionSelected,
                 onSuggestionsBoxToggle: onSuggestionsBoxToggle,
                 itemBuilder: itemBuilder,
-                itemSeparatorBuilder: itemSeparatorBuilder,
+                layoutArchitecture: layoutArchitecture,
                 suggestionsCallback: suggestionsCallback,
                 animationStart: animationStart,
                 animationDuration: animationDuration,
@@ -123,7 +124,6 @@ class TypeAheadFormField<T> extends FormField<String> {
                 hideKeyboardOnDrag: hideKeyboardOnDrag,
               );
             });
-
   @override
   _TypeAheadFormFieldState<T> createState() => _TypeAheadFormFieldState<T>();
 }

--- a/lib/src/typedef.dart
+++ b/lib/src/typedef.dart
@@ -9,3 +9,5 @@ typedef Widget ErrorBuilder(BuildContext context, Object? error);
 
 typedef Widget AnimationTransitionBuilder(
     BuildContext context, Widget child, AnimationController? controller);
+typedef LayoutArchitecture = Widget Function(
+    Iterable<Widget> items, ScrollController controller);


### PR DESCRIPTION
Support alternative (for example Grid) layouts of results, removed top padding on scrollbar from cupertino typehead.
