### PR TITLE
Fix for scrollbar clickthrough

### DIFF
--- a/lib/src/material/suggestions_box/suggestions_list.dart
+++ b/lib/src/material/suggestions_box/suggestions_list.dart
@@ -428,6 +428,8 @@ class _SuggestionsListState<T> extends State<SuggestionsList<T>>
       );
     }
 
+    child = TextFieldTapRegion(child: child);
+    
     return child;
   }
 
@@ -464,6 +466,8 @@ class _SuggestionsListState<T> extends State<SuggestionsList<T>>
         ),
       );
     }
+
+    child = TextFieldTapRegion(child: child);
 
     return child;
   }


### PR DESCRIPTION
This change prevents the selection dropdown from closing when a user attempts to drag the dropdown scrollbar, thus allowing scrollbar dragging on desktop/web :)

All credit goes to @matthieurosset

Issue: #477 