### PR TITLE
Fix mouse events propagating through the SuggestionBox to the underlying HTMLElementView

### DIFF
--- a/lib/src/material/field/typeahead_field.dart
+++ b/lib/src/material/field/typeahead_field.dart
@@ -12,6 +12,7 @@ import 'package:flutter_typeahead/src/material/suggestions_box/suggestions_box_d
 import 'package:flutter_typeahead/src/material/suggestions_box/suggestions_list.dart';
 import 'package:flutter_typeahead/src/typedef.dart';
 import 'package:flutter_typeahead/src/utils.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 /// # Flutter TypeAhead
 /// A TypeAhead widget for Flutter, where you can show suggestions to
@@ -378,6 +379,10 @@ class TypeAheadField<T> extends StatefulWidget {
   ///
   /// If not specified, the error is shown in [ThemeData.errorColor](https://docs.flutter.io/flutter/material/ThemeData/errorColor.html)
   final ErrorBuilder? errorBuilder;
+  
+  /// Used to overcome [Flutter issue 98507](https://github.com/flutter/flutter/issues/98507)
+  /// Most commonly experienced when placing the [TypeAheadFormField] on a google map in Flutter Web.
+  final bool intercepting;
 
   /// Called to display animations when [suggestionsCallback] returns suggestions
   ///
@@ -538,6 +543,7 @@ class TypeAheadField<T> extends StatefulWidget {
     required this.itemBuilder,
     this.itemSeparatorBuilder,
     this.layoutArchitecture,
+    this.intercepting = false,
     required this.onSuggestionSelected,
     this.textFieldConfiguration = const TextFieldConfiguration(),
     this.suggestionsBoxDecoration = const SuggestionsBoxDecoration(),
@@ -763,6 +769,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
           suggestionsBox: _suggestionsBox,
           decoration: widget.suggestionsBoxDecoration,
           debounceDuration: widget.debounceDuration,
+          intercepting: widget.intercepting,
           controller: this._effectiveController,
           loadingBuilder: widget.loadingBuilder,
           scrollController: widget.scrollController,
@@ -863,7 +870,9 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   Widget build(BuildContext context) {
     return CompositedTransformTarget(
       link: this._layerLink,
-      child: TextField(
+      child: PointerInterceptor(
+        intercepting: widget.intercepting,
+              child: TextField(
           focusNode: this._effectiveFocusNode,
           controller: this._effectiveController,
           decoration: widget.textFieldConfiguration.decoration,
@@ -898,6 +907,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
               widget.textFieldConfiguration.enableInteractiveSelection,
           readOnly: widget.hideKeyboard,
           autofillHints: widget.textFieldConfiguration.autofillHints),
+        ),
     );
   }
 }

--- a/lib/src/material/field/typeahead_form_field.dart
+++ b/lib/src/material/field/typeahead_form_field.dart
@@ -58,6 +58,7 @@ class TypeAheadFormField<T> extends FormField<String> {
       bool hideOnEmpty = false,
       bool hideOnError = false,
       bool hideSuggestionsOnKeyboardHide = true,
+      bool intercepting = false,
       bool keepSuggestionsOnLoading = true,
       bool keepSuggestionsOnSuggestionSelected = false,
       bool autoFlipDirection = false,
@@ -116,6 +117,7 @@ class TypeAheadFormField<T> extends FormField<String> {
                 keepSuggestionsOnLoading: keepSuggestionsOnLoading,
                 keepSuggestionsOnSuggestionSelected:
                     keepSuggestionsOnSuggestionSelected,
+                intercepting: intercepting,
                 autoFlipDirection: autoFlipDirection,
                 autoFlipListDirection: autoFlipListDirection,
                 autoFlipMinHeight: autoFlipMinHeight,

--- a/lib/src/material/suggestions_box/suggestions_list.dart
+++ b/lib/src/material/suggestions_box/suggestions_list.dart
@@ -26,6 +26,7 @@ class SuggestionsList<T> extends StatefulWidget {
   final SuggestionsBoxDecoration? decoration;
   final Duration? debounceDuration;
   final WidgetBuilder? loadingBuilder;
+  final bool intercepting;
   final WidgetBuilder? noItemsFoundBuilder;
   final ErrorBuilder? errorBuilder;
   final AnimationTransitionBuilder? transitionBuilder;
@@ -48,6 +49,7 @@ class SuggestionsList<T> extends StatefulWidget {
   SuggestionsList({
     required this.suggestionsBox,
     this.controller,
+    this.intercepting = false,
     this.getImmediateSuggestions = false,
     this.onSuggestionSelected,
     this.suggestionsCallback,
@@ -292,9 +294,7 @@ class _SuggestionsListState<T> extends State<SuggestionsList<T>>
             sizeFactor: CurvedAnimation(
                 parent: this._animationController!,
                 curve: Curves.fastOutSlowIn),
-            child: PointerInterceptor(
-                child: child,
-            ),
+            child: child,
           );
 
     BoxConstraints constraints;
@@ -311,7 +311,9 @@ class _SuggestionsListState<T> extends State<SuggestionsList<T>>
       );
     }
 
-    var container = Material(
+    var container = PointerInterceptor(
+      intercepting: widget.intercepting,
+                child: Material(
       elevation: widget.decoration!.elevation,
       color: widget.decoration!.color,
       shape: widget.decoration!.shape,
@@ -322,7 +324,7 @@ class _SuggestionsListState<T> extends State<SuggestionsList<T>>
         constraints: constraints,
         child: animationChild,
       ),
-    );
+    ));
 
     return container;
   }

--- a/lib/src/material/suggestions_box/suggestions_list.dart
+++ b/lib/src/material/suggestions_box/suggestions_list.dart
@@ -8,6 +8,7 @@ import 'package:flutter_typeahead/src/should_refresh_suggestion_focus_index_noti
 import 'package:flutter_typeahead/src/material/suggestions_box/suggestions_box.dart';
 import 'package:flutter_typeahead/src/material/suggestions_box/suggestions_box_decoration.dart';
 import 'package:flutter_typeahead/src/typedef.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 /// Renders all the suggestions using a ListView as default.  If
 /// `layoutArchitecture` is specified, uses that instead.
@@ -291,7 +292,9 @@ class _SuggestionsListState<T> extends State<SuggestionsList<T>>
             sizeFactor: CurvedAnimation(
                 parent: this._animationController!,
                 curve: Curves.fastOutSlowIn),
-            child: child,
+            child: PointerInterceptor(
+                child: child,
+            ),
           );
 
     BoxConstraints constraints;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_keyboard_visibility: ^5.4.1
+  pointer_interceptor: ^0.9.3+4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Flutter Web has a bug where when you place widgets on top of `HtmlElementView`, the click events propagate to the `HtmlElementView`. See [98507](https://github.com/flutter/flutter/issues/98507). This presents itself when placing the `TypeAheadFormField` on a `google_maps_flutter` map in web. 

It is observable in this situation, where the suggestion box drops over a clickable button, as shown below. When you select a suggestion above "view on google maps", it opens a new tab, the google maps web page, which displays the location details.

<img width="344" alt="Screenshot 2023-06-02 at 5 00 08 PM" src="https://github.com/AbdulRahmanAlHamali/flutter_typeahead/assets/26356162/685e6211-4863-45b2-a318-1c310766d235">

Flutter has created a widget that works around this issue: [PointerInterceptor](https://pub.dev/packages/pointer_interceptor).  It adds nothing to the widget tree in Android and iOS or if `intercepting` is set to false - which I have made the default. 

Since it occurs on the suggestion box created in the `TypeAheadFormField`, the `PointerInterceptor` needs to be applied there, not in the client code using this package. I've also added it to the `TextField` which experienced the same issue.