### PR TITLE
ignoreAccessibleNavigation flag to prevent non-selection bug

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ If you plan to submit a PR please do the following:
 
 - Fork the repository
 - Create a feature branch from the **master** branch!
-- Following the coding guidlines below
+- Following the coding guidelines below
 - Submit the PR against the **master** branch.
 - Update both Material and Cupertino code if applicable
 
-## General coding guidlines
+## General coding guidelines
 
 If you'd like to add a feature or fix a bug, we're more than happy to accept pull requests! We only ask a few things:
 

--- a/lib/src/material/field/typeahead_field.dart
+++ b/lib/src/material/field/typeahead_field.dart
@@ -379,7 +379,7 @@ class TypeAheadField<T> extends StatefulWidget {
   ///
   /// If not specified, the error is shown in [ThemeData.errorColor](https://docs.flutter.io/flutter/material/ThemeData/errorColor.html)
   final ErrorBuilder? errorBuilder;
-  
+
   /// Used to overcome [Flutter issue 98507](https://github.com/flutter/flutter/issues/98507)
   /// Most commonly experienced when placing the [TypeAheadFormField] on a google map in Flutter Web.
   final bool intercepting;
@@ -534,6 +534,12 @@ class TypeAheadField<T> extends StatefulWidget {
   /// Defaults to false
   final bool hideKeyboardOnDrag;
 
+  /// Allows a bypass of a problem on Flutter 3.7+ with the accessibility through Overlay
+  /// that prevents flutter_typeahead to register a click on the list of suggestions properly.
+  ///
+  /// Defaults to false
+  final bool ignoreAccessibleNavigation;
+
   // Adds a callback for the suggestion box opening or closing
   final void Function(bool)? onSuggestionsBoxToggle;
 
@@ -572,6 +578,7 @@ class TypeAheadField<T> extends StatefulWidget {
     this.minCharsForSuggestions = 0,
     this.onSuggestionsBoxToggle,
     this.hideKeyboardOnDrag = false,
+    this.ignoreAccessibleNavigation = false,
     super.key,
   })  : assert(animationStart >= 0.0 && animationStart <= 1.0),
         assert(
@@ -848,7 +855,8 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       // the style visually. However, when VO/TB are not enabled it is
       // necessary to use the Positioned widget to allow the elements to be
       // properly tappable.
-      return MediaQuery.of(context).accessibleNavigation
+      return MediaQuery.of(context).accessibleNavigation &&
+              !widget.ignoreAccessibleNavigation
           ? Semantics(
               container: true,
               child: Align(
@@ -872,42 +880,44 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       link: this._layerLink,
       child: PointerInterceptor(
         intercepting: widget.intercepting,
-              child: TextField(
-          focusNode: this._effectiveFocusNode,
-          controller: this._effectiveController,
-          decoration: widget.textFieldConfiguration.decoration,
-          style: widget.textFieldConfiguration.style,
-          textAlign: widget.textFieldConfiguration.textAlign,
-          enabled: widget.textFieldConfiguration.enabled,
-          keyboardType: widget.textFieldConfiguration.keyboardType,
-          autofocus: widget.textFieldConfiguration.autofocus,
-          inputFormatters: widget.textFieldConfiguration.inputFormatters,
-          autocorrect: widget.textFieldConfiguration.autocorrect,
-          maxLines: widget.textFieldConfiguration.maxLines,
-          textAlignVertical: widget.textFieldConfiguration.textAlignVertical,
-          minLines: widget.textFieldConfiguration.minLines,
-          maxLength: widget.textFieldConfiguration.maxLength,
-          maxLengthEnforcement:
-              widget.textFieldConfiguration.maxLengthEnforcement,
-          obscureText: widget.textFieldConfiguration.obscureText,
-          onChanged: widget.textFieldConfiguration.onChanged,
-          onSubmitted: widget.textFieldConfiguration.onSubmitted,
-          onEditingComplete: widget.textFieldConfiguration.onEditingComplete,
-          onTap: widget.textFieldConfiguration.onTap,
-          onTapOutside: widget.textFieldConfiguration.onTapOutside,
-          scrollPadding: widget.textFieldConfiguration.scrollPadding,
-          textInputAction: widget.textFieldConfiguration.textInputAction,
-          textCapitalization: widget.textFieldConfiguration.textCapitalization,
-          keyboardAppearance: widget.textFieldConfiguration.keyboardAppearance,
-          cursorWidth: widget.textFieldConfiguration.cursorWidth,
-          cursorRadius: widget.textFieldConfiguration.cursorRadius,
-          cursorColor: widget.textFieldConfiguration.cursorColor,
-          textDirection: widget.textFieldConfiguration.textDirection,
-          enableInteractiveSelection:
-              widget.textFieldConfiguration.enableInteractiveSelection,
-          readOnly: widget.hideKeyboard,
-          autofillHints: widget.textFieldConfiguration.autofillHints),
-        ),
+        child: TextField(
+            focusNode: this._effectiveFocusNode,
+            controller: this._effectiveController,
+            decoration: widget.textFieldConfiguration.decoration,
+            style: widget.textFieldConfiguration.style,
+            textAlign: widget.textFieldConfiguration.textAlign,
+            enabled: widget.textFieldConfiguration.enabled,
+            keyboardType: widget.textFieldConfiguration.keyboardType,
+            autofocus: widget.textFieldConfiguration.autofocus,
+            inputFormatters: widget.textFieldConfiguration.inputFormatters,
+            autocorrect: widget.textFieldConfiguration.autocorrect,
+            maxLines: widget.textFieldConfiguration.maxLines,
+            textAlignVertical: widget.textFieldConfiguration.textAlignVertical,
+            minLines: widget.textFieldConfiguration.minLines,
+            maxLength: widget.textFieldConfiguration.maxLength,
+            maxLengthEnforcement:
+                widget.textFieldConfiguration.maxLengthEnforcement,
+            obscureText: widget.textFieldConfiguration.obscureText,
+            onChanged: widget.textFieldConfiguration.onChanged,
+            onSubmitted: widget.textFieldConfiguration.onSubmitted,
+            onEditingComplete: widget.textFieldConfiguration.onEditingComplete,
+            onTap: widget.textFieldConfiguration.onTap,
+            onTapOutside: widget.textFieldConfiguration.onTapOutside,
+            scrollPadding: widget.textFieldConfiguration.scrollPadding,
+            textInputAction: widget.textFieldConfiguration.textInputAction,
+            textCapitalization:
+                widget.textFieldConfiguration.textCapitalization,
+            keyboardAppearance:
+                widget.textFieldConfiguration.keyboardAppearance,
+            cursorWidth: widget.textFieldConfiguration.cursorWidth,
+            cursorRadius: widget.textFieldConfiguration.cursorRadius,
+            cursorColor: widget.textFieldConfiguration.cursorColor,
+            textDirection: widget.textFieldConfiguration.textDirection,
+            enableInteractiveSelection:
+                widget.textFieldConfiguration.enableInteractiveSelection,
+            readOnly: widget.hideKeyboard,
+            autofillHints: widget.textFieldConfiguration.autofillHints),
+      ),
     );
   }
 }

--- a/lib/src/material/field/typeahead_form_field.dart
+++ b/lib/src/material/field/typeahead_form_field.dart
@@ -66,7 +66,8 @@ class TypeAheadFormField<T> extends FormField<String> {
       double autoFlipMinHeight = 64.0,
       bool hideKeyboard = false,
       int minCharsForSuggestions = 0,
-      bool hideKeyboardOnDrag = false})
+      bool hideKeyboardOnDrag = false,
+      bool ignoreAccessibleNavigation = false})
       : assert(
             initialValue == null || textFieldConfiguration.controller == null),
         assert(minCharsForSuggestions >= 0),
@@ -125,6 +126,7 @@ class TypeAheadFormField<T> extends FormField<String> {
                 hideKeyboard: hideKeyboard,
                 minCharsForSuggestions: minCharsForSuggestions,
                 hideKeyboardOnDrag: hideKeyboardOnDrag,
+                ignoreAccessibleNavigation: ignoreAccessibleNavigation,
               );
             });
   @override


### PR DESCRIPTION
See #463 for the bug description.

This is a bypass fix (so not an _actual_ fix), but allows devs to choose to disable the accessibility functionality in exchange for things actually working. Hopefully we can soon find a better solution and throw this in the trash.

I tested this out with a very nice user that installed a dev version and confirmed he can now select suggestions perfectly fine.

Running `dartfmt` formatted other things in the affected file.

Also fixes a typo in the CONTRIBUTING.md.