### PR TITLE
Fix: Add missing argument 'enableSuggestions' in TypeAheadField

### DIFF
--- a/lib/src/cupertino/field/cupertino_typeahead_field.dart
+++ b/lib/src/cupertino/field/cupertino_typeahead_field.dart
@@ -566,6 +566,7 @@ class _CupertinoTypeAheadFieldState<T> extends State<CupertinoTypeAheadField<T>>
         autofocus: widget.textFieldConfiguration.autofocus,
         obscureText: widget.textFieldConfiguration.obscureText,
         autocorrect: widget.textFieldConfiguration.autocorrect,
+        enableSuggestions: widget.textFieldConfiguration.enableSuggestions,
         maxLines: widget.textFieldConfiguration.maxLines,
         minLines: widget.textFieldConfiguration.minLines,
         maxLength: widget.textFieldConfiguration.maxLength,

--- a/lib/src/material/field/typeahead_field.dart
+++ b/lib/src/material/field/typeahead_field.dart
@@ -895,6 +895,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
           autofocus: widget.textFieldConfiguration.autofocus,
           inputFormatters: widget.textFieldConfiguration.inputFormatters,
           autocorrect: widget.textFieldConfiguration.autocorrect,
+          enableSuggestions: widget.textFieldConfiguration.enableSuggestions,
           expands: widget.textFieldConfiguration.expands,
           maxLines: widget.textFieldConfiguration.maxLines,
           textAlignVertical: widget.textFieldConfiguration.textAlignVertical,


### PR DESCRIPTION
Class `TextFieldConfiguration` has a field named `enableSuggestions` which is supposed to be sent as an argument to `TextField` but isn't. I fixed that.