### PR TITLE
Fix setState() called after dispose()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.0.1 - 2023-11-27
+### Fixed
+- SetState error in suggestions box
+
 ## 5.0.0 - 2023-11-25
 ### Added
 - Custom `TextField` builder via the `builder` property, replacing `TextFieldConfiguration`.

--- a/lib/src/common/base/floater.dart
+++ b/lib/src/common/base/floater.dart
@@ -243,6 +243,7 @@ class _FloaterState extends State<Floater> with WidgetsBindingObserver {
 
   void updateOverlay() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
       setState(() {});
       controller.show();
     });


### PR DESCRIPTION
When using modal bottom sheets with a TypeAheadField, it comes to a exception when the modal gets closed while the suggestions are shown:

```
======== Exception caught by scheduler library =====================================================
The following assertion was thrown during a scheduler callback:
setState() called after dispose(): _FloaterState#00ebb(lifecycle state: defunct, not mounted)

This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.

The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().

When the exception was thrown, this was the stack: 
#0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1167:9)
#1      State.setState (package:flutter/src/widgets/framework.dart:1202:6)
#2      _FloaterState.updateOverlay.<anonymous closure> (package:flutter_typeahead/src/common/base/floater.dart:246:7)
#3      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1325:15)
#4      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1264:9)
#5      SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1113:5)
#9      _invoke (dart:ui/hooks.dart:314:10)
#10     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:383:5)
#11     _drawFrame (dart:ui/hooks.dart:283:31)
(elided 3 frames from dart:async)
====================================================================================================


======== Exception caught by scheduler library =====================================================
The following assertion was thrown during a scheduler callback:
setState() called after dispose(): _FloaterState#00ebb(lifecycle state: defunct, not mounted)

This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.

The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().

When the exception was thrown, this was the stack: 
#0      State.setState.<anonymous closure> (package:flutter/src/widgets/framework.dart:1167:9)
#1      State.setState (package:flutter/src/widgets/framework.dart:1202:6)
#2      _FloaterState.updateOverlay.<anonymous closure> (package:flutter_typeahead/src/common/base/floater.dart:246:7)
#3      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1325:15)
#4      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1264:9)
#5      SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1113:5)
#9      _invoke (dart:ui/hooks.dart:314:10)
#10     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:383:5)
#11     _drawFrame (dart:ui/hooks.dart:283:31)
(elided 3 frames from dart:async)
====================================================================================================
```