### PR TITLE
feat: add itemBorderRadius and wrap itemBuilder with IgnorePointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `itemBorderRadius` parameter to `TypeAheadField` and `CupertinoTypeAheadField` (#584)
+
+### Fixed
+- Mouse cursor doesn't change to pointer-hand when ListTile is returned in itemBuilder (#584)
+
 ## 5.2.0 - 2024-02-08
 ### Added
 - force refreshing suggestions with `SuggestionsController.refresh`

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ TypeAheadField<City>(
       )
     );
   },
+  itemBorderRadius: BorderRadius.circular(8),
   itemBuilder: (context, city) {
     return ListTile(
       title: Text(city.name),
@@ -256,6 +257,8 @@ You must then specify the following parameters:
 - `itemBuilder` (to build the suggestions)
 
 As well as all the usual parameters, such as `suggestionsCallback`, `onSelected`, etc.
+
+If you want to set border radius to the suggestion items, doing it inside `itemBuilder` probably won't work. Use `itemBorderRadius` parameter instead.
 
 The `decorationBuilder` can be used to inject required wrappers like `Material` or `DefaultTextStyle`.
 For more information, see the source code of the `TypeAheadField` widget.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -92,6 +92,7 @@ class ExampleTypeAhead extends StatelessWidget
                   borderRadius: borderRadius,
                   child: child,
                 ),
+                itemBorderRadius: BorderRadius.circular(8),
                 itemBuilder: (context, product) => ListTile(
                   title: Text(product.name),
                   subtitle: product.description != null
@@ -224,6 +225,7 @@ class CupertinoExampleTypeAhead extends StatelessWidget
                   ),
                   child: child,
                 ),
+                itemBorderRadius: BorderRadius.circular(8),
                 itemBuilder: (context, product) => CupertinoListTile(
                   title: Text(product.name),
                   subtitle: product.description != null

--- a/example/lib/settings.dart
+++ b/example/lib/settings.dart
@@ -42,6 +42,7 @@ class SettingsTypeAhead extends StatelessWidget
                 hintText: hintText,
               ),
             ),
+            itemBorderRadius: BorderRadius.circular(8),
             itemBuilder: (context, setting) {
               if (setting is ToggleFieldOption) {
                 IconData? icon = setting.value
@@ -125,6 +126,7 @@ class CupertinoSettingsTypeAhead extends StatelessWidget
                         fontStyle: FontStyle.italic,
                       ),
             ),
+            itemBorderRadius: BorderRadius.circular(8),
             itemBuilder: (context, setting) {
               if (setting is ToggleFieldOption) {
                 return CupertinoListTile(

--- a/lib/src/cupertino/cupertino_defaults.dart
+++ b/lib/src/cupertino/cupertino_defaults.dart
@@ -50,14 +50,18 @@ abstract final class TypeAheadCupertinoDefaults {
   /// Provides the functionality to select an item on tap.
   static SuggestionsItemBuilder<T> itemBuilder<T>(
     SuggestionsItemBuilder<T> builder,
+    BorderRadius itemBorderRadius,
   ) {
     return (context, item) {
-      return FocusableActionDetector(
-        mouseCursor: SystemMouseCursors.click,
-        child: GestureDetector(
-          behavior: HitTestBehavior.opaque,
-          child: builder(context, item),
-          onTap: () => SuggestionsController.of<T>(context).select(item),
+      return ClipRRect(
+        borderRadius: itemBorderRadius,
+        child: FocusableActionDetector(
+          mouseCursor: SystemMouseCursors.click,
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            child: IgnorePointer(child: builder(context, item)),
+            onTap: () => SuggestionsController.of<T>(context).select(item),
+          ),
         ),
       );
     };

--- a/lib/src/cupertino/typeahead_field.dart
+++ b/lib/src/cupertino/typeahead_field.dart
@@ -29,6 +29,7 @@ class CupertinoTypeAheadField<T> extends RawTypeAheadField<T> {
     super.hideOnUnfocus,
     super.hideWithKeyboard,
     super.hideOnSelect,
+    BorderRadius itemBorderRadius = BorderRadius.zero,
     required SuggestionsItemBuilder<T> itemBuilder,
     super.itemSeparatorBuilder,
     super.retainOnLoading,
@@ -49,7 +50,8 @@ class CupertinoTypeAheadField<T> extends RawTypeAheadField<T> {
           loadingBuilder:
               loadingBuilder ?? TypeAheadCupertinoDefaults.loadingBuilder,
           emptyBuilder: emptyBuilder ?? TypeAheadCupertinoDefaults.emptyBuilder,
-          itemBuilder: TypeAheadCupertinoDefaults.itemBuilder(itemBuilder),
+          itemBuilder: TypeAheadCupertinoDefaults.itemBuilder(
+              itemBuilder, itemBorderRadius),
           decorationBuilder:
               TypeAheadCupertinoDefaults.wrapperBuilder(decorationBuilder),
         );

--- a/lib/src/material/material_defaults.dart
+++ b/lib/src/material/material_defaults.dart
@@ -47,12 +47,14 @@ abstract final class TypeAheadMaterialDefaults {
   /// Provides the functionality to select an item on tap.
   static SuggestionsItemBuilder<T> itemBuilder<T>(
     SuggestionsItemBuilder<T> builder,
+    BorderRadius itemBorderRadius,
   ) {
     return (context, item) {
       return InkWell(
+        borderRadius: itemBorderRadius,
         focusColor: Theme.of(context).hoverColor,
         onTap: () => SuggestionsController.of<T>(context).select(item),
-        child: builder(context, item),
+        child: IgnorePointer(child: builder(context, item)),
       );
     };
   }

--- a/lib/src/material/typeahead_field.dart
+++ b/lib/src/material/typeahead_field.dart
@@ -29,6 +29,7 @@ class TypeAheadField<T> extends RawTypeAheadField<T> {
     super.hideOnUnfocus,
     super.hideWithKeyboard,
     super.hideOnSelect,
+    BorderRadius itemBorderRadius = BorderRadius.zero,
     required SuggestionsItemBuilder<T> itemBuilder,
     super.itemSeparatorBuilder,
     super.retainOnLoading,
@@ -49,7 +50,8 @@ class TypeAheadField<T> extends RawTypeAheadField<T> {
           loadingBuilder:
               loadingBuilder ?? TypeAheadMaterialDefaults.loadingBuilder,
           emptyBuilder: emptyBuilder ?? TypeAheadMaterialDefaults.emptyBuilder,
-          itemBuilder: TypeAheadMaterialDefaults.itemBuilder(itemBuilder),
+          itemBuilder: TypeAheadMaterialDefaults.itemBuilder(
+              itemBuilder, itemBorderRadius),
           decorationBuilder:
               TypeAheadMaterialDefaults.wrapperBuilder(decorationBuilder),
         );


### PR DESCRIPTION
### Description

Fixes https://github.com/AbdulRahmanAlHamali/flutter_typeahead/issues/585
Fixes https://github.com/AbdulRahmanAlHamali/flutter_typeahead/issues/586

This PR does 2 things:
1. Adds a new property `itemBorderRadius` which will be applied on the default `itemBuilder` that is wrapped on the `itemBuilder` passed by the user.
2. Wraps the `itemBuilder` passed by the user with an `IgnorePointer` so that the interaction behaviour (ex. mouse hover) of the wrapping default `itemBuilder` is not affected. This shouldn't really change much for the user as any `onTap` or `onPress` event from the passed `itemBuilder` is being ignored already due to the default `itemBuilder`.

### Checklist

Please check if your PR fulfils the following requirements:

- [x] I have read the [Contributor Guide](CONTRIBUTING.md)
- [x] I have filed an issue for the change  
       [#Issue Number]
- [x] All code is formatted with `dartfmt`
- [x] All code passes analysis with no errors or warnings
- [x] Changes work for both Material and Cupertino
- [x] New code has documentation where needed
- [x] New code has test coverage if applicable
- [x] All existing tests pass
- [x] Example project still compiles and runs
- [x] Changes have been documented in [CHANGELOG.md](CHANGELOG.md)  
       Using the [Keep A Changelog format](https://keepachangelog.com/en/1.0.0/).  
       You may use [cider](https://pub.dev/packages/cider) to help with this.
- [x] New code has been documented in the [README.md](README.md) if applicable
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
