### PR TITLE
Avoid inconsequential RenderBox was not laid out console logging when used inside a Stack

### DIFF
--- a/lib/src/common/base/floater.dart
+++ b/lib/src/common/base/floater.dart
@@ -388,24 +388,29 @@ class _FloaterState extends State<Floater> with WidgetsBindingObserver {
 
   ({Size size, Offset offset, EdgeInsets viewPadding}) getOverlayConstraints(
       OverlayState overlay) {
-    final RenderBox overlayBox =
-        overlay.context.findRenderObject()! as RenderBox;
+    final RenderBox? overlayBox =
+        overlay.context.findRenderObject() as RenderBox?;
 
-    Offset overlayOffset = overlayBox.localToGlobal(Offset.zero);
-    Size overlaySize = overlayBox.size;
+    Offset overlayOffset = Offset.zero;
+    Size overlaySize = Size.zero;
+    final EdgeInsets viewPadding = MediaQuery.of(overlay.context).padding;
 
-    MediaQueryData mediaQuery = MediaQuery.of(overlay.context);
-    EdgeInsets viewPadding = mediaQuery.padding;
+    if (overlayBox != null && overlayBox.hasSize) {
+      bool canComputeConstraints = true;
+      try {
+        overlayOffset = overlayBox.localToGlobal(Offset.zero);
+      } catch (e) {
+        if (e is AssertionError) {
+          canComputeConstraints = false;
+        } else {
+          rethrow;
+        }
+      }
 
-    overlayOffset = Offset(
-      overlayOffset.dx,
-      overlayOffset.dy,
-    );
-
-    overlaySize = Size(
-      overlaySize.width,
-      overlaySize.height,
-    );
+      if (canComputeConstraints) {
+        overlaySize = overlayBox.size;
+      }
+    }
 
     return (
       size: overlaySize,


### PR DESCRIPTION
### Description

Potential fix for https://github.com/AbdulRahmanAlHamali/flutter_typeahead/issues/623. It's pretty tricky to diagnose exact cause of this, as it doesn't happen on all of my usages of`TypeAheadField`. The one it happens to on is in a `Positioned` inside a `Stack` widget. Since it happens under certain circumstances I've used some defensive coding and also quietening the console error, since the behaviour is always unaffected. 

BTW, there are a lot of changes in master. Will they be released soon?

### Checklist

Please check if your PR fulfills the following requirements:

- [ ] I have read the [Contributor Guide](CONTRIBUTING.md)
- [ ] I have filed an issue for the change  
       [#Issue Number]
- [ ] All code is formatted with `dartfmt`
- [ ] All code passes analysis with no errors or warnings
- [ ] Changes work for both Material and Cupertino
- [ ] New code has documentation where needed
- [ ] New code has test coverage if applicable
- [ ] All existing tests pass
- [ ] Example project still compiles and runs
- [ ] Changes have been documented in [CHANGELOG.md](CHANGELOG.md)  
       Using the [Keep A Changelog format](https://keepachangelog.com/en/1.0.0/).  
       You may use [cider](https://pub.dev/packages/cider) to help with this.
- [ ] New code has been documented in the [README.md](README.md) if applicable
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format
